### PR TITLE
Adding optional network and application parameters to accessories

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,15 @@
 
 Make your home CBus accessories controllable using Apple's HomeKit with your [Homebridge](https://github.com/nfarina/homebridge) server.
 
-This projects provides a bridge between your CBus local server and HomeKit. Thus, once you setup your homebridge server, poof - all of your supported accessories will be instantly controllable via HomeKit.
+This project provides a bridge between your CBus local server and HomeKit. Thus, once you setup your homebridge server, poof - all of your supported accessories will be instantly controllable via HomeKit.
 
-What does that means? You'll be able to:
+This is a fork of Anthony Webb's excellent [CBus plugin](https://github.com/gbrooker/homebridge-cbus) for homebridge to add:
+0.5.1:  adds optional "network" and "application" parameters per accessory, allowing multiple networks and device types
+        be monitored or controlled. 
+        NB if upgrading from an ealier version of homebridge-cbus, you may need to remove the files in 
+        your ~/.homebridge/persist/ directory before running for the first time due to new devide uuid's
+
+What does that mean? You'll be able to:
 * Control your home using each app in the App Store which supports the HomeKit protocol.
 * Control your home using voice commands via Siri.
 * Use the built-in Home app (iOS 10+) to control your home.
@@ -16,7 +22,7 @@ To see some action of homekit controlling a clipsal cbus system check out the fo
 
 ## Device Support
 
-CBus already provides a fully supported home automation platform. Hence, this project that provides a bridge which "expose' your devices in a way that you can control then using HomeKit.
+CBus already provides a fully supported home automation platform. Hence, this project provides a bridge which "exposes' your devices in a way that you can control then using HomeKit.
 
 We are working on adding device types, but for now you'll only be able to control:
 * Lightblubs.
@@ -30,6 +36,8 @@ After installing and setting up [Homebridge](https://github.com/nfarina/homebrid
     npm install -g homebridge-cbus
 
 Once installed, update your Homebridge's `config.json`.
+
+NOTE: you will need a CBus [C-Gate server](http://www2.clipsal.com/cis/technical/downloads/c-gate) on your network. This is a cross platform Java application which runs on most platforms. 
 
 ## Configuration
 
@@ -62,8 +70,8 @@ c-gate server, you will likely need to configure c-gate for remote connections.
 * `client_controlport`: (optional) Your CBus control port number.
 * `client_eventport`: (optional) Your CBus event port number.
 * `client_statusport`: (optional) Your CBus status port number.
-* `client_network`: (optional) The network address for your CBus network.
-* `client_application`: (optional) The application address for your CBus network.
+* `client_network`: (optional) The network address for your CBus network (defaults to 254)
+* `client_application`: (optional) The application address for your CBus network (defaults to 56).
 * `client_debug`: (optional) Write CBus client debug logs to the console.
 * `accessories`: (required) List of accessories which you'd like to expose to the homebridge server.
 
@@ -71,6 +79,8 @@ c-gate server, you will likely need to configure c-gate for remote connections.
 Right now we are registering devices by hand.  In the future we may auto discover them. The platform definition in the `config.json` file contains an `accessories` array, which constitudes from objects with the following keys:
 * `type`: (required) The type of the accessory. The valid values are "light", "motion", and "dimmer".
 * `name`: (required) The name of the accessory (e.g. "Living room light", "Beedroom light", "Living Room curtain" etc.).
+* `network`: (optional) The CBus network address of the device. Defaults to client_network.
+* `application`: (optional) The CBus Application address of the device. Defaults to client_application.
 * `id`: (required) The id of the device. Each accessory in CBus has one.
 
 #### Fully functional example config.json:
@@ -102,7 +112,9 @@ Right now we are registering devices by hand.  In the future we may auto discove
         { "type": "light", "id": "0", "name": "Flood" },
         { "type": "light", "id": "1", "name": "Main Bay" },
         { "type": "light", "id": "2", "name": "3rd Bay" },
-        { "type": "dimmer", "id": "3", "name": "Closet" },
+        { "type": "light", "network": "250", "id": "1", "name": "Outside light" },
+        { "type": "light", "network": "250", "application": "203", "id": "3", "name": "Backdoor" },
+        { "type": "dimmer", "id": "3", "name": "Closet" }2
         { "type": "motion", "id": "51", "name": "Main" }
       ]
     }

--- a/README.md
+++ b/README.md
@@ -5,10 +5,8 @@ Make your home CBus accessories controllable using Apple's HomeKit with your [Ho
 This project provides a bridge between your CBus local server and HomeKit. Thus, once you setup your homebridge server, poof - all of your supported accessories will be instantly controllable via HomeKit.
 
 This is a fork of Anthony Webb's excellent [CBus plugin](https://github.com/gbrooker/homebridge-cbus) for homebridge to add:
-0.5.1:  adds optional "network" and "application" parameters per accessory, allowing multiple networks and device types
-        be monitored or controlled. 
-        NB if upgrading from an ealier version of homebridge-cbus, you may need to remove the files in 
-        your ~/.homebridge/persist/ directory before running for the first time due to new devide uuid's
+
+0.5.1:  adds optional "network" and "application" parameters per accessory, allowing multiple networks and device types be monitored or controlled. NB if upgrading from an ealier version of homebridge-cbus, you may need to remove the files in your ~/.homebridge/persist/ directory before running for the first time due to new devide uuid's
 
 What does that mean? You'll be able to:
 * Control your home using each app in the App Store which supports the HomeKit protocol.
@@ -114,7 +112,7 @@ Right now we are registering devices by hand.  In the future we may auto discove
         { "type": "light", "id": "2", "name": "3rd Bay" },
         { "type": "light", "network": "250", "id": "1", "name": "Outside light" },
         { "type": "light", "network": "250", "application": "203", "id": "3", "name": "Backdoor" },
-        { "type": "dimmer", "id": "3", "name": "Closet" }2
+        { "type": "dimmer", "id": "3", "name": "Closet" },
         { "type": "motion", "id": "51", "name": "Main" }
       ]
     }

--- a/accessories/accessory.js
+++ b/accessories/accessory.js
@@ -33,6 +33,10 @@ function CBusAccessory(platform, accessoryData)
         this.log.error("The specified id (" + accessoryData.id + ") is invalid. ABORTING.");
         process.exit(0);
     }
+    
+    var networkID = accessoryData.network || platform.client.clientNetwork;
+    var applicationID = accessoryData.application || platform.client.clientApplication;
+    
 
     //--------------------------------------------------
     //  Define our iVars
@@ -43,8 +47,8 @@ function CBusAccessory(platform, accessoryData)
     this.accessoryData  =   accessoryData;
     this.log            =   platform.log;
 
-    this.id             =   this.accessoryData.id;
-    this.uuid_base      =   this.accessoryData.uuid_base;
+    this.id             =   cbusUtils.idForCbusAddress(networkID, applicationID, this.accessoryData.id);
+    this.uuid_base      =   this.id //NB ignore this.accessoryData.uuid_base as it is only based on group id
     this.name           =   this.accessoryData.name;
     this.type           =   typeof(this.accessoryData.type) != "undefined" ? this.accessoryData.type : undefined;
 
@@ -59,7 +63,7 @@ function CBusAccessory(platform, accessoryData)
     var s = this.getService(Service.AccessoryInformation);
     
     s.setCharacteristic(Characteristic.Manufacturer, "CBus")
-        .setCharacteristic(Characteristic.SerialNumber, String(this.id));
+        .setCharacteristic(Characteristic.SerialNumber, cbusUtils.cbusAddressForId(this.id));
     
     if (this.type) {
         s.setCharacteristic(Characteristic.Model, this.type);
@@ -71,5 +75,5 @@ CBusAccessory.prototype.getServices = function() {
 };
 
 CBusAccessory.prototype._log = function(tag, message) {
-    this.log.info("[" + tag + "] [" + this.accessoryData.id + ", " + this.accessoryData.name + "]: " + message);
+    this.log.info("[" + tag + "] [" + cbusUtils.cbusAddressForId(this.id) + ", " + this.name + "]: " + message);
 }

--- a/cbus-utils.js
+++ b/cbus-utils.js
@@ -39,3 +39,31 @@ module.exports.fixInheritance = function(subclass, superclass) {
 module.exports.clamp = function(value, min, max) {
     return Math.max(max, Math.min(min, value));
 };
+
+
+/**
+ * Turns a CBus address into a string of an encoded integer
+ * @example idForCbusAddress(254, 56, 1)
+ */
+module.exports.idForCbusAddress = function(networkID, applicationID, groupID) {
+    
+    return String(((networkID & 0xFF) << 16) | ((applicationID & 0xFF) << 8) | (groupID & 0xFF));
+
+}
+
+
+/**
+ * Turns an encoded moduleID into a CGate CBus address
+ * @example cbusAddressForId(0xfe3401)
+ */
+module.exports.cbusAddressForId = function(deviceID) {
+
+    var id = Number(deviceID);
+    
+    var groupID = id & 0xFF;
+    var applicationID = (id >>> 8) & 0xFF;
+    var networkID = (id >>> 16) & 0xFF;
+    
+    return networkID+'/'+applicationID+'/'+groupID;
+
+}

--- a/index.js
+++ b/index.js
@@ -121,14 +121,14 @@ CBusPlatform.prototype.accessories = function(callback) {
     // listen for data from the client and ensure that the homebridge UI is updated
     this.client.on("remoteData", function(data){
         if(this.clientDebug){
-            this.log.info("[remoteData] id:"+data.group);
+            this.log.info("[remoteData] id:"+data.moduleId);
         }
         var devs = this.foundAccessories;
         for (var i = 0; i < devs.length; i++) {
             var dev = devs[i];
-            if(dev.id == data.group){
+            if(dev.id == data.moduleId){
                 if(this.clientDebug){
-                    this.log.info("[remoteDataFound] id:"+data.group+" type:"+dev.type+" level:"+data.level);
+                    this.log.info("[remoteDataFound] id:"+data.moduleId+" type:"+dev.type+" level:"+data.level);
                 }
                 if(dev.type == "light"){
                     if(data.level > 0) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-cbus",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "CBus Platform plugin for homebridge",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
Anthony, Andrew,

I've created a fork to add changes to Anthony's version 0.5.0, to provide optional network and application parameters for each accessory. I've been running it a couple of days and it seems to work fine.

This also includes the fix I posted on the issues list, which allows project names to contain digits.

I plan to add a new "security" accessory shortly to monitor PIR motion detectors (application 208) 

Cheers
Guy
