### PR TITLE
Add security accessory for PIR motion detectors (CBus application 208)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ Make your home CBus accessories controllable using Apple's HomeKit with your [Ho
 
 This project provides a bridge between your CBus local server and HomeKit. Thus, once you setup your homebridge server, poof - all of your supported accessories will be instantly controllable via HomeKit.
 
-This is a fork of Anthony Webb's excellent [CBus plugin](https://github.com/gbrooker/homebridge-cbus) for homebridge to add:
+Changes since 0.5.0:
+
+0.5.2:  adds a "security" accessory, for a PIR presence detector, typically application 208
 
 0.5.1:  adds optional "network" and "application" parameters per accessory, allowing multiple networks and device types be monitored or controlled. NB if upgrading from an ealier version of homebridge-cbus, you may need to remove the files in your ~/.homebridge/persist/ directory before running for the first time due to new devide uuid's
 
@@ -25,7 +27,8 @@ CBus already provides a fully supported home automation platform. Hence, this pr
 We are working on adding device types, but for now you'll only be able to control:
 * Lightblubs.
 * Dimmers.
-* Motion Sensors.
+* Motion Sensors
+* Security Presence Detectors
 
 ## Installation
 
@@ -113,7 +116,8 @@ Right now we are registering devices by hand.  In the future we may auto discove
         { "type": "light", "network": "250", "id": "1", "name": "Outside light" },
         { "type": "light", "network": "250", "application": "203", "id": "3", "name": "Backdoor" },
         { "type": "dimmer", "id": "3", "name": "Closet" },
-        { "type": "motion", "id": "51", "name": "Main" }
+        { "type": "motion", "id": "51", "name": "Main" },
+        { "type": "security", "application": "208", "id": "1", "name": "Entry Zone" }
       ]
     }
   ],

--- a/accessories/security-accessory.js
+++ b/accessories/security-accessory.js
@@ -1,0 +1,34 @@
+var Service, Characteristic, CBusAccessory, uuid;
+
+module.exports = function (_service, _characteristic, _accessory, _uuid) {
+    Service = _service;
+    Characteristic = _characteristic;
+    CBusAccessory = _accessory;
+    uuid = _uuid;
+    
+    return CBusSecurityAccessory;
+};
+
+function CBusSecurityAccessory(platform, accessoryData)
+{
+    //--------------------------------------------------
+    //  Initialize the parent
+    //--------------------------------------------------
+    CBusAccessory.call(this, platform, accessoryData);
+    
+    //--------------------------------------------------
+    //  Register the on-off service
+    //--------------------------------------------------
+    this.motionService = this.addService(new Service.MotionSensor(this.name));
+    this.motionService.getCharacteristic(Characteristic.MotionDetected)
+    .on('get', this.getMotionState.bind(this));
+};
+
+CBusSecurityAccessory.prototype.getMotionState = function(callback, context) {
+    setTimeout(function() {
+               this.client.receiveSecurityStatus(this.id, function(result) {
+                                              this._log("CBusSecurityAccessory", "getState = " + result.level);
+                                              callback(false, /*state: */ result.level ? 1 : 0);
+                                              }.bind(this));
+               }.bind(this), 50);
+};

--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ var CBusAccessory;
 var CBusLightAccessory;
 var CBusDimmerAccessory;
 var CBusMotionAccessory;
+var CBusSecurityAccessory;
 
 //==========================================================================================
 //  Exports block
@@ -30,12 +31,14 @@ module.exports = function(homebridge) {
     CBusLightAccessory   = require('./accessories/light-accessory.js')(Service, Characteristic, CBusAccessory, uuid);
     CBusDimmerAccessory  = require('./accessories/dimmer-accessory.js')(Service, Characteristic, CBusLightAccessory, uuid);
     CBusMotionAccessory   = require('./accessories/motion-accessory.js')(Service, Characteristic, CBusAccessory, uuid);
+    CBusSecurityAccessory = require('./accessories/security-accessory.js')(Service, Characteristic, CBusAccessory, uuid);
 
     /* Fix inheritance, since we've loaded our classes before the Accessory class has been loaded */
     cbusUtils.fixInheritance(CBusAccessory, Accessory);
     cbusUtils.fixInheritance(CBusLightAccessory, CBusAccessory);
     cbusUtils.fixInheritance(CBusDimmerAccessory, CBusLightAccessory);
     cbusUtils.fixInheritance(CBusMotionAccessory, CBusAccessory);
+    cbusUtils.fixInheritance(CBusSecurityAccessory, CBusAccessory);
 
     //--------------------------------------------------
     //  Register ourselfs with homebridge
@@ -136,6 +139,7 @@ CBusPlatform.prototype.accessories = function(callback) {
                     } else if (data.level == 0) {
                         dev.lightService.getCharacteristic(Characteristic.On).setValue(false, undefined, 'remoteData');    
                     }
+                
                 } else if (dev.type == "dimmer"){
                     if (data.level == 0) {
                         dev.lightService.getCharacteristic(Characteristic.On).setValue(false, undefined, 'remoteData');    
@@ -146,7 +150,11 @@ CBusPlatform.prototype.accessories = function(callback) {
                     
                 } else if (dev.type == "motion"){
                     dev.motionService.getCharacteristic(Characteristic.MotionDetected).setValue(data.level > 0 ? true:false);
+                
+                } else if (dev.type == "security") {
+                    dev.motionService.getCharacteristic(Characteristic.MotionDetected).setValue(data.level > 0 ? true:false);
                 }
+
                 
             }
         }
@@ -190,6 +198,8 @@ CBusPlatform.prototype.accessoryFactory = function(entry) {
             return new CBusDimmerAccessory(this, entry);
         case "motion":
             return new CBusMotionAccessory(this, entry);
+        case "security":
+            return new CBusSecurityAccessory(this, entry);
         default:
             return undefined;
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-cbus",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "CBus Platform plugin for homebridge",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
Hi Anthony,

this pull request builds on yesterdays network and application extension, to add a 'security' device, such as a PIR motion detector, which is typically CBus application type 208.

It will trigger a motion event if the security zone is entered (CBus security zone_unsealed, zone_open or zone_short are reported). It switches off when the detector signals no presence (zone_sealed).

I note that the existing motion accessory is actually monitoring the status of a switch or light, but looks the same to HomeKit. 

Hope this is useful.

Next thought is auto detecting the accessories on a network...

Cheers
Guy

