### PR TITLE
Fix to stop the code crashing when receiving group events from the CB…

### DIFF
--- a/index.js
+++ b/index.js
@@ -123,7 +123,11 @@ CBusPlatform.prototype._processEvent = function (message) {
 		if (typeof message.sourceunit !== `undefined`) {
 			const sourceId = new CBusNetId(this.project, this.network, `p`, message.sourceunit);
 			const source = this.database.getNetworkEntity(sourceId);
-			output = `${output}, by ${chalk.red.bold(source.tag)} (${source.unitType})`;
+            if (typeof source == 'undefined') {
+                log(`event source unit ${sourceId} not found.`);
+            } else {
+			    output = `${output}, by ${chalk.red.bold(source.tag)} (${source.unitType})`;
+            }
 		}
 
 		logLevel(output);


### PR DESCRIPTION
…US controller.  See the following event and stack trace as an example of the problem fixed by this code change:

cbus:client rx event { time: '20200331-210451', code: 730, processed: true, netId: //UNIT5/254/56/21, level: 100, sourceunit: 103, ramptime: 0, type: 'event', raw: '#e# 20200331-210451 730 //UNIT5/254/56/21 - new level=255 sourceunit=103 ramptime=0' } +9s
  cbus:client rx unparsable line: '#e# 20200331-210451 730 //UNIT5/254/56/21 - new level=255 sourceunit=103 ramptime=0', error: TypeError: Cannot read property 'tag' of undefined
  cbus:client     at CBusPlatform._processEvent (/usr/local/lib/node_modules/homebridge-cbus/index.js:126:52)
  cbus:client     at CBusPlatform.<anonymous> (/usr/local/lib/node_modules/homebridge-cbus/index.js:153:8)
  cbus:client     at emitOne (events.js:116:13)
  cbus:client     at CBusClient.emit (events.js:211:7)
  cbus:client     at CBusClient._socketReceivedLine (/usr/local/lib/node_modules/homebridge-cbus/lib/cgate-client.js:641:10)
  cbus:client     at Carrier.<anonymous> (/usr/local/lib/node_modules/homebridge-cbus/lib/cgate-client.js:175:9)
  cbus:client     at emitOne (events.js:116:13)
  cbus:client     at Carrier.emit (events.js:211:7)
  cbus:client     at /usr/local/lib/node_modules/homebridge-cbus/node_modules/carrier/lib/carrier.js:24:12
  cbus:client     at _combinedTickCallback (internal/process/next_tick.js:131:7)
  cbus:client     at process._tickCallback (internal/process/next_tick.js:180:9) +7ms