### PR TITLE
Modernize plugin for current Homebridge/HAP-NodeJS and Node

### DIFF
--- a/accessories/accessory.js
+++ b/accessories/accessory.js
@@ -1,90 +1,87 @@
 'use strict';
 
-let Service;
-let Characteristic;
-let Accessory;
-let uuid;
-
-require('../hot-debug.js');
-const log = require('debug')('cbus:accessory');
-
-const chalk = require('chalk'); // does not alter string prototype
+const debug = require('debug')('cbus:accessory');
+const chalk = require('chalk');
 
 const cbusUtils = require('../lib/cbus-utils.js');
 const CBusNetId = require('../lib/cbus-netid.js');
 
-module.exports = function (_service, _characteristic, _accessory, _uuid) {
-	Service = _service;
-	Characteristic = _characteristic;
-	Accessory = _accessory;
-	uuid = _uuid;
-
-	return CBusAccessory;
-};
-
-function CBusAccessory(platform, accessoryData) {
-	// type is absolutely required
-	console.assert(typeof accessoryData.type !== `undefined`, `accessoryData.type must not be undefined`);
-
-	this.client = platform.client;
-	this.accessoryData = accessoryData;
-	this.type = accessoryData.type;
-
-	// ensure we have a name
-	if (typeof accessoryData.name !== `string`) {
-		throw new Error(`missing required 'name' field`);
-	}
-	this.name = accessoryData.name;
-
-	// ensure we have a valid group address
-	if (typeof accessoryData.id === `undefined`) {
-		throw new Error(`accessory '${this.name} missing required 'id' (group address) field`);
-	}
-
-	let groupAddress;
-	try {
-		groupAddress = cbusUtils.integerise(accessoryData.id);
-	} catch (err) {
-		throw new Error(`id '${accessoryData.id}' for accessory '${this.name} is not an integer`);
-	}
-
-	if (typeof accessoryData.action !== `undefined`) {
-		let actionValue;
+// Base class for all CBus accessory types. Wraps a homebridge PlatformAccessory
+// (composition) rather than subclassing hap-nodejs's Accessory -- hap-nodejs's
+// Accessory is a real ES6 class these days and can't be extended via
+// Accessory.call(this, ...) the way older versions of this plugin did.
+class CBusAccessory {
+	// computes the CBusNetId for a config entry; shared by the platform (to look up
+	// a cached PlatformAccessory by uuid before construction) and the constructor below
+	static netIdFor(platform, accessoryData) {
+		let groupAddress;
 		try {
-			actionValue = cbusUtils.integerise(accessoryData.action);
+			groupAddress = cbusUtils.integerise(accessoryData.id);
 		} catch (err) {
-			throw new Error(`action value '${accessoryData.action}' for accessory '${this.name} is not an integer`);
+			throw new Error(`id '${accessoryData.id}' for accessory '${accessoryData.name}' is not an integer`);
 		}
+
+		return new CBusNetId(
+			platform.project,
+			accessoryData.network || platform.client.network,
+			accessoryData.application || platform.client.application,
+			groupAddress,
+			accessoryData.channel
+		);
 	}
 
-	// build netId
-	this.netId = new CBusNetId(
-		platform.project,
-		accessoryData.network || platform.client.network,
-		accessoryData.application || platform.client.application,
-		groupAddress,
-		accessoryData.channel
-	);
+	static uuidFor(platform, accessoryData) {
+		const netId = CBusAccessory.netIdFor(platform, accessoryData);
+		return platform.api.hap.uuid.generate(netId.getHash());
+	}
 
-	// fire our parent
-	const ourUUID = uuid.generate(this.netId.getHash());
-	Accessory.call(this, this.name, ourUUID);
+	constructor(platform, accessoryData, existingPlatformAccessory) {
+		console.assert(typeof accessoryData.type !== `undefined`, `accessoryData.type must not be undefined`);
 
-	// setup service
-	const service = this.getService(Service.AccessoryInformation);
+		this.platform = platform;
+		this.api = platform.api;
+		this.hap = platform.api.hap;
+		this.client = platform.client;
+		this.accessoryData = accessoryData;
+		this.type = accessoryData.type;
 
-	// configure service
-	service.setCharacteristic(Characteristic.Manufacturer, `Clipsal C-Bus`);
-	service.setCharacteristic(Characteristic.SerialNumber, this.netId.toString());
-	service.setCharacteristic(Characteristic.Model, this.type);
+		if (typeof accessoryData.name !== `string`) {
+			throw new Error(`missing required 'name' field`);
+		}
+		this.name = accessoryData.name;
+
+		if (typeof accessoryData.id === `undefined`) {
+			throw new Error(`accessory '${this.name}' missing required 'id' (group address) field`);
+		}
+
+		this.netId = CBusAccessory.netIdFor(platform, accessoryData);
+
+		const uuid = this.hap.uuid.generate(this.netId.getHash());
+		this.platformAccessory = existingPlatformAccessory || new this.api.platformAccessory(this.name, uuid);
+		this.platformAccessory.displayName = this.name;
+		this.platformAccessory.context.netId = this.netId.toString();
+
+		const infoService = this.getService(this.hap.Service.AccessoryInformation) ||
+			this.addService(this.hap.Service.AccessoryInformation);
+
+		infoService.setCharacteristic(this.hap.Characteristic.Manufacturer, `Clipsal C-Bus`);
+		infoService.setCharacteristic(this.hap.Characteristic.SerialNumber, this.netId.toString());
+		infoService.setCharacteristic(this.hap.Characteristic.Model, this.type);
+	}
+
+	addService(...args) {
+		return this.platformAccessory.addService(...args);
+	}
+
+	getService(...args) {
+		return this.platformAccessory.getService(...args);
+	}
+
+	_log(file, action, message) {
+		const fileName = file.split(`-`)[0];
+		const accessoryLabel = cbusUtils.formatTag(this.name, this.netId);
+		debug(`${chalk.gray.bold(fileName)} ${accessoryLabel} ${chalk.red(action)} ${message}`);
+	}
 }
 
-CBusAccessory.prototype.getServices = function () {
-	return this.services;
-};
-
-CBusAccessory.prototype._log = function (file, action, message) {
-	const fileName = file.split(`-`)[0];
-	const accessoryLabel = cbusUtils.formatTag(this.name, this.netId);
-	log(`${chalk.gray.bold(fileName)} ${accessoryLabel} ${chalk.red(action)} ${message}`);
-};
+module.exports = CBusAccessory;

--- a/accessories/contact-accessory.js
+++ b/accessories/contact-accessory.js
@@ -1,52 +1,34 @@
 'use strict';
 
-let Service;
-let Characteristic;
-let CBusAccessory;
-let uuid;
-
+const CBusAccessory = require('./accessory.js');
 const cbusUtils = require('../lib/cbus-utils.js');
 
 const FILE_ID = cbusUtils.extractIdentifierFromFileName(__filename);
 
-module.exports = function (_service, _characteristic, _accessory, _uuid) {
-	Service = _service;
-	Characteristic = _characteristic;
-	CBusAccessory = _accessory;
-	uuid = _uuid;
+class CBusContactAccessory extends CBusAccessory {
+	constructor(platform, accessoryData, existingPlatformAccessory) {
+		super(platform, accessoryData, existingPlatformAccessory);
 
-	return CBusContactAccessory;
-};
+		// register on-off service
+		this.service = this.getService(this.hap.Service.ContactSensor) ||
+			this.addService(this.hap.Service.ContactSensor, this.name);
 
-function CBusContactAccessory(platform, accessoryData) {
-	//--------------------------------------------------
-	// initialize parent
-	CBusAccessory.call(this, platform, accessoryData);
-
-	//--------------------------------------------------
-	// register on-off service
-    this.service = this.addService(new Service.ContactSensor(this.name));
-    this.service.getCharacteristic(Characteristic.ContactSensorState)
-        .on('get', this.getMotionState.bind(this));
-
-
-    }
-
-CBusContactAccessory.prototype.getMotionState = function (callback) {
-	this.client.receiveLevel(this.netId, message => {
-        this._log(FILE_ID, `getState`, message.level);
-        const level = message.level;
-        console.log("Contact Sensor level is=", level);
-		callback(false, /* state: */ message.level ? 1 : 0);
-	});
-};
-
-CBusContactAccessory.prototype.processClientData = function (err, message) {
-	if (!err) {
-        const level = message.level;
-        console.log("Contact Sensor level is=",level);
-        this.service.getCharacteristic(Characteristic.ContactSensorState)
-            .setValue((level > 0) ? 1 : 0);
-
+		this.service.getCharacteristic(this.hap.Characteristic.ContactSensorState)
+			.onGet(this.getMotionState.bind(this));
 	}
-};
+
+	async getMotionState() {
+		const message = await new Promise(resolve => this.client.receiveLevel(this.netId, resolve));
+		this._log(FILE_ID, `getState`, message.level);
+		return message.level > 0;
+	}
+
+	processClientData(err, message) {
+		if (!err) {
+			this.service.getCharacteristic(this.hap.Characteristic.ContactSensorState)
+				.updateValue(message.level > 0);
+		}
+	}
+}
+
+module.exports = CBusContactAccessory;

--- a/accessories/dimmer-accessory.js
+++ b/accessories/dimmer-accessory.js
@@ -1,50 +1,36 @@
 'use strict';
 
-let Service;
-let Characteristic;
-let CBusLightAccessory;
-let uuid;
-
 const chalk = require('chalk');
-
 const ms = require('ms');
 
+const CBusLightAccessory = require('./light-accessory.js');
 const cbusUtils = require('../lib/cbus-utils.js');
 
 const FILE_ID = cbusUtils.extractIdentifierFromFileName(__filename);
 
-module.exports = function (_service, _characteristic, _accessory, _uuid) {
-	Service = _service;
-	Characteristic = _characteristic;
-	CBusLightAccessory = _accessory;
-	uuid = _uuid;
+class CBusDimmerAccessory extends CBusLightAccessory {
+	constructor(platform, accessoryData, existingPlatformAccessory) {
+		super(platform, accessoryData, existingPlatformAccessory);
 
-	return CBusDimmerAccessory;
-};
-
-function CBusDimmerAccessory(platform, accessoryData) {
-	// initialize parent
-	CBusLightAccessory.call(this, platform, accessoryData);
-
-	// if we have an activeDuration specified, stash it away
-	if (typeof accessoryData.rampDuration !== `undefined`) {
-		this.rampDuration = ms(accessoryData.rampDuration);
-		if (this.rampDuration > ms(`17m`)) {
-			throw new Error(`accessory '${this.name} rampDuration (${ms(this.rampDuration)}) is greater than maximum (17m)`);
+		// if we have an activeDuration specified, stash it away
+		if (typeof accessoryData.rampDuration !== `undefined`) {
+			this.rampDuration = ms(accessoryData.rampDuration);
+			if (this.rampDuration > ms(`17m`)) {
+				throw new Error(`accessory '${this.name}' rampDuration (${ms(this.rampDuration)}) is greater than maximum (17m)`);
+			}
+			this._log(FILE_ID, `constructed`, `ramp up/down over ${this.rampDuration}ms when activated via homebridge`);
 		}
-		this._log(FILE_ID, `constructed`, `ramp up/down over ${this.rampDuration}ms when activated via homebridge`);
+
+		// register brightness service
+		this.brightnessCharacteristic = this.service.getCharacteristic(this.hap.Characteristic.Brightness);
+
+		this.brightnessCharacteristic
+			.onGet(this.getBrightness.bind(this))
+			.onSet(this.setBrightness.bind(this));
 	}
 
-	// register brightness service
-	this.brightnessC10tic = this.service.getCharacteristic(Characteristic.Brightness);
-
-	this.brightnessC10tic
-		.on('get', this.getBrightness.bind(this))
-		.on('set', this.setBrightness.bind(this));
-}
-
-CBusDimmerAccessory.prototype.getBrightness = function (callback) {
-	this.client.receiveLevel(this.netId, message => {
+	async getBrightness() {
+		const message = await new Promise(resolve => this.client.receiveLevel(this.netId, resolve, `getBrightness`));
 		this._log(FILE_ID, `getBrightness`, `returned ${message.level}%`);
 
 		if (message.level) {
@@ -52,44 +38,39 @@ CBusDimmerAccessory.prototype.getBrightness = function (callback) {
 			this.brightness = message.level;
 		}
 
-		callback(/* error */ false, /* newValue */ message.level);
-	}, `getBrightness`);
-};
+		return message.level;
+	}
 
-CBusDimmerAccessory.prototype.setBrightness = function (newLevel, callback, context) {
-	this.brightness = newLevel;
-	const wasOn = this.isOn;
-	this.isOn = (this.brightness > 0);
+	async setBrightness(newLevel) {
+		this.brightness = newLevel;
+		const wasOn = this.isOn;
+		this.isOn = this.brightness > 0;
 
-	if (context === `event`) {
-		// context helps us avoid a never-ending loop
-		callback();
-	} else {
 		if (!wasOn && (newLevel === 0)) {
 			this._log(FILE_ID, `setBrightness`, chalk.green(`swallowing 0%`));
-			callback();
-		} else {
-			this._log(FILE_ID, `setBrightness`, `changing level to ${newLevel}%`);
-			this.client.setLevel(this.netId, newLevel, function () {
-				callback();
-			}, this.rampDuration / 1000, `setBrightness`);
+			return;
+		}
+
+		this._log(FILE_ID, `setBrightness`, `changing level to ${newLevel}%`);
+		await new Promise(resolve => this.client.setLevel(this.netId, newLevel, resolve, this.rampDuration / 1000, `setBrightness`));
+	}
+
+	processClientData(err, message) {
+		if (!err) {
+			console.assert(typeof message.level !== `undefined`, `CBusDimmerAccessory.processClientData must receive message.level`);
+			const level = message.level;
+
+			// pick up the special cases of 'on' and 'off'
+			this.onCharacteristic.updateValue(level > 0);
+
+			// update brightness
+			if (level === 0) {
+				this._log(FILE_ID, `processClientData`, `level 0%; interpreting as 'off'`);
+			} else {
+				this.brightnessCharacteristic.updateValue(level);
+			}
 		}
 	}
-};
+}
 
-CBusDimmerAccessory.prototype.processClientData = function (err, message) {
-	if (!err) {
-		console.assert(typeof message.level !== `undefined`, `CBusDimmerAccessory.processClientData must receive message.level`);
-		const level = message.level;
-
-		// pick up the special cases of 'on' and 'off'
-		this.onC10tic.setValue((level > 0) ? 1 : 0, undefined, `event`);
-
-		// update brightness
-		if (level === 0) {
-			this._log(FILE_ID, `processClientData`, `level 0%; interpreting as 'off'`);
-		} else {
-			this.brightnessC10tic.setValue(level, undefined, `event`);
-		}
-	}
-};
+module.exports = CBusDimmerAccessory;

--- a/accessories/fan-accessory.js
+++ b/accessories/fan-accessory.js
@@ -1,166 +1,132 @@
 'use strict';
 
-let Service;
-let Characteristic;
-let CBusAccessory;
-let uuid;
+const chalk = require('chalk');
 
-let cbusUtils = require('../lib/cbus-utils.js');
-
-const chalk = require('chalk'); // does not alter string prototype
+const CBusAccessory = require('./accessory.js');
+const cbusUtils = require('../lib/cbus-utils.js');
 
 const FILE_ID = cbusUtils.extractIdentifierFromFileName(__filename);
 
-const SPIN_TIME = 3000;
+class CBusFanAccessory extends CBusAccessory {
+	constructor(platform, accessoryData, existingPlatformAccessory) {
+		super(platform, accessoryData, existingPlatformAccessory);
 
-module.exports = function (_service, _characteristic, _accessory, _uuid) {
-	Service = _service;
-	Characteristic = _characteristic;
-	CBusAccessory = _accessory;
-	uuid = _uuid;
+		// register the service
+		this.service = this.getService(this.hap.Service.Fan) ||
+			this.addService(this.hap.Service.Fan, this.name);
 
-	return CBusFanAccessory;
-};
+		this.onCharacteristic = this.service.getCharacteristic(this.hap.Characteristic.On);
+		this.speedCharacteristic = this.service.getCharacteristic(this.hap.Characteristic.RotationSpeed);
 
-function CBusFanAccessory(platform, accessoryData) {
-	//--------------------------------------------------
-	// initialize the parent
-	CBusAccessory.call(this, platform, accessoryData);
+		this.onCharacteristic
+			.onGet(this.getOn.bind(this))
+			.onSet(this.setOn.bind(this));
 
-	//--------------------------------------------------
-	// register the service
-	this.service = this.addService(new Service.Fan(this.name));
+		// the current fan speed (0-100%)
+		this.speedCharacteristic
+			.onGet(this.getSpeed.bind(this))
+			.onSet(this.setSpeed.bind(this));
 
-	this.onC10tic = this.service.getCharacteristic(Characteristic.On);
-	this.speedC10tic = this.service.getCharacteristic(Characteristic.RotationSpeed);
+		// prime the fan state
+		this.isOn = false;
+		this.speed = 0;
 
-	this.onC10tic
-		.on('get', this.getOn.bind(this))
-		.on('set', this.setOn.bind(this));
-
-	// the current fan speed (0-100%)
-	// https://github.com/KhaosT/HAP-NodeJS/blob/master/lib/gen/HomeKitTypes.js#L1557
-	this.speedC10tic
-		.on('get', this.getSpeed.bind(this))
-		.on('set', this.setSpeed.bind(this));
-
-	//--------------------------------------------------
-	// prime the fan state
-	this.isOn = false;
-	this.speed = 0;
-
-	// TODO work out whether we really do need to prime
-	// it seems that the Home app kicks off an update only when activating the app,
-	// but not automatically if homekit is restarted.
-	setTimeout(() => {
-		this._log(FILE_ID, `construct`, `prime state`);
-		this.getSpeed((err, speed) => {
-			if (!err) {
-				this.isOn = (speed > 0);
+		// it seems that the Home app kicks off an update only when activating the app,
+		// but not automatically if homekit is restarted.
+		setTimeout(async () => {
+			this._log(FILE_ID, `construct`, `prime state`);
+			try {
+				const speed = await this.getSpeed();
+				this.isOn = speed > 0;
 				this.speed = speed;
 
-				this.onC10tic.setValue(this.isOn ? 1 : 0, undefined, `event`);
-				this.speedC10tic.setValue(this.speed, undefined, `event`);
+				this.onCharacteristic.updateValue(this.isOn);
+				this.speedCharacteristic.updateValue(this.speed);
+			} catch (err) {
+				this._log(FILE_ID, `construct`, `failed to prime state: ${err}`);
 			}
-		});
-	}, 3000);
-}
+		}, 3000);
+	}
 
-CBusFanAccessory.prototype.getOn = function (callback) {
-	this.client.receiveLevel(this.netId, message => {
+	async getOn() {
+		const message = await new Promise(resolve => this.client.receiveLevel(this.netId, resolve, `getOn`));
 		this._log(FILE_ID, `getOn receiveLevel returned ${message.level}%`);
-		this.isOn = (message.level > 0);
+		this.isOn = message.level > 0;
 		if (this.isOn) {
 			this.speed = message.level;
 		}
 
-		callback(false, this.isOn ? 1 : 0);
-	}, `getOn`);
-};
+		return this.isOn;
+	}
 
-CBusFanAccessory.prototype.setOn = function (turnOn, callback, context) {
-	// delay by a fraction of a second to give setSpeed a chance to work first
-	setTimeout(() => {
+	async setOn(turnOn) {
+		// delay by a fraction of a second to give setSpeed a chance to work first
+		await cbusUtils.delay(50);
+
 		const wasOn = this.isOn;
 		this.isOn = (turnOn === 1) || (turnOn === true);
 
-		if (context === `event`) {
-			// context helps us avoid a never-ending loop
-			callback();
-		} else {
-			if (wasOn === this.isOn) {
-				this._log(FILE_ID, `setOn`, `no state change from ${wasOn}`);
-				callback();
-			} else {
-				const speed = turnOn ? this.speed : 0;
-
-				if (this.isOn && speed === 0) {
-					this._log(FILE_ID, `setOn`, chalk.green.bold(`SWALLOW! *** not sure why if this is still needed -- remove? ***`));
-					callback();
-				} else {
-					this._log(FILE_ID, `setOn`, `changing level to ${speed}%`);
-					this.client.setLevel(this.netId, speed, function () {
-						callback();
-					}, 0, `setOn`);
-				}
-			}
+		if (wasOn === this.isOn) {
+			this._log(FILE_ID, `setOn`, `no state change from ${wasOn}`);
+			return;
 		}
-	}, 50);
-};
 
-CBusFanAccessory.prototype.getSpeed = function (callback) {
-	this.client.receiveLevel(this.netId, message => {
+		const speed = this.isOn ? this.speed : 0;
+
+		if (this.isOn && speed === 0) {
+			this._log(FILE_ID, `setOn`, chalk.green.bold(`swallowing on with speed 0`));
+			return;
+		}
+
+		this._log(FILE_ID, `setOn`, `changing level to ${speed}%`);
+		await new Promise(resolve => this.client.setLevel(this.netId, speed, resolve, 0, `setOn`));
+	}
+
+	async getSpeed() {
+		const message = await new Promise(resolve => this.client.receiveLevel(this.netId, resolve, `getSpeed`));
 		const speed = message.level;
 		this._log(FILE_ID, `getSpeed`, `receiveLevel returned ${speed}%`);
-		this.isOn = (speed > 0);
-		
+		this.isOn = speed > 0;
+
 		if (speed > 0) {
 			// update speed if the speed is non-zero
 			this.speed = speed;
 		}
 
-		if (callback) {
-			callback(/* error */ false, /* newValue */ this.speed);
-		}
-	}, `getSpeed`);
-};
+		return this.speed;
+	}
 
-CBusFanAccessory.prototype.setSpeed = function (newSpeed, callback, context) {
-	this.speed = newSpeed;
-	const wasOn = this.isOn;
-	this.isOn = (newSpeed > 0);
+	async setSpeed(newSpeed) {
+		this.speed = newSpeed;
+		const wasOn = this.isOn;
+		this.isOn = newSpeed > 0;
 
-	if (context === `event`) {
-		// context helps us avoid a never-ending loop
-		callback();
-	} else {
 		if (!wasOn && (newSpeed === 0)) {
 			this._log(FILE_ID, `setSpeed`, chalk.green(`swallowing 0%`));
-			callback();
-		} else {
-			this._log(FILE_ID, `setSpeed`, `changing speed to ${newSpeed}%`);
-			this.client.setLevel(this.netId, newSpeed, function () {
-				callback();
-			}, 0, `setSpeed`);
+			return;
+		}
+
+		this._log(FILE_ID, `setSpeed`, `changing speed to ${newSpeed}%`);
+		await new Promise(resolve => this.client.setLevel(this.netId, newSpeed, resolve, 0, `setSpeed`));
+	}
+
+	// received an event over the network -- could have been in response to one of our commands, or someone else
+	processClientData(err, message) {
+		if (!err) {
+			console.assert(typeof message.level !== `undefined`, `CBusFanAccessory.processClientData must receive message.level`);
+			const speed = message.level;
+
+			// update isOn
+			this.onCharacteristic.updateValue(speed > 0);
+
+			// update speed
+			if (speed === 0) {
+				this._log(FILE_ID, `processClientData`, `speed 0%; interpreting as 'off'`);
+			} else {
+				this.speedCharacteristic.updateValue(speed);
+			}
 		}
 	}
-};
+}
 
-// received an event over the network
-// could have been in response to one of our commands, or someone else
-CBusFanAccessory.prototype.processClientData = function (err, message) {
-	if (!err) {
-		console.assert(typeof message.level !== `undefined`, `CBusFanAccessory.processClientData must receive message.level`);
-		const speed = message.level;
-
-		// update isOn
-		this.onC10tic.setValue((speed > 0) ? 1 : 0, undefined, `event`);
-
-		// update speed
-		if (speed === 0) {
-			this._log(FILE_ID, `processClientData`, `speed 0%; interpreting as 'off'`);
-		} else {
-			this.speedC10tic.setValue(speed, undefined, `event`);
-		}
-	}
-};
+module.exports = CBusFanAccessory;

--- a/accessories/light-accessory.js
+++ b/accessories/light-accessory.js
@@ -1,89 +1,67 @@
 'use strict';
 
-let Service;
-let Characteristic;
-let CBusAccessory;
-let uuid;
-
-const chalk = require('chalk');
-
+const CBusAccessory = require('./accessory.js');
 const cbusUtils = require('../lib/cbus-utils.js');
 
 const FILE_ID = cbusUtils.extractIdentifierFromFileName(__filename);
 
-module.exports = function (_service, _characteristic, _accessory, _uuid) {
-	Service = _service;
-	Characteristic = _characteristic;
-	CBusAccessory = _accessory;
-	uuid = _uuid;
+class CBusLightAccessory extends CBusAccessory {
+	constructor(platform, accessoryData, existingPlatformAccessory) {
+		super(platform, accessoryData, existingPlatformAccessory);
 
-	return CBusLightAccessory;
-};
+		// keep track of state
+		this.isOn = false;
+		this.brightness = 100;
+		this.rampDuration = 0; // duration in ms
 
-function CBusLightAccessory(platform, accessoryData) {
-	//--------------------------------------------------
-	// initialize  parent
-	CBusAccessory.call(this, platform, accessoryData);
+		// register on-off service
+		this.service = this.getService(this.hap.Service.Lightbulb) ||
+			this.addService(this.hap.Service.Lightbulb, this.name);
 
-	//--------------------------------------------------
-	// keep track of state
-	// TODO do we need to prime this?
-	this.isOn = false;
-	this.brightness = 100;
-	this.rampDuration = 0;		// duration in ms
+		this.onCharacteristic = this.service.getCharacteristic(this.hap.Characteristic.On);
 
-	//--------------------------------------------------
-	// register on-off service
-	this.service = this.addService(new Service.Lightbulb(this.name));
+		this.onCharacteristic
+			.onGet(this.getOn.bind(this))
+			.onSet(this.setOn.bind(this));
+	}
 
-	this.onC10tic = this.service.getCharacteristic(Characteristic.On);
-
-	this.onC10tic
-		.on('get', this.getOn.bind(this))
-		.on('set', this.setOn.bind(this));
-}
-
-CBusLightAccessory.prototype.getOn = function (callback) {
-	this.client.receiveLevel(this.netId, message => {
-		this.isOn = (message.level > 0);
+	async getOn() {
+		const message = await new Promise(resolve => this.client.receiveLevel(this.netId, resolve, `getOn`));
+		this.isOn = message.level > 0;
 		this._log(FILE_ID, `getOn`, `receiveLevel returned ${message.level}`);
-		callback(false, this.isOn ? 1 : 0);
-	}, `getOn`);
-};
+		return this.isOn;
+	}
 
-CBusLightAccessory.prototype.setOn = function (turnOn, callback, context) {
-	// delay by a fraction of a second to give any superclass (nb. there may not be one) a chance to work first
-	setTimeout(() => {
-		// it appears that Siri uses true/false but the Home app uses 1/0 -- odd!
+	async setOn(turnOn) {
+		// delay by a fraction of a second to give any subclass (nb. there may not be one) a chance to work first
+		await cbusUtils.delay(50);
+
 		console.assert((turnOn === 1) || (turnOn === 0) || (turnOn === true) || (turnOn === false));
 		const wasOn = this.isOn;
 		this.isOn = (turnOn === 1) || (turnOn === true);
 
-		if (context === `event`) {
-			// context helps us avoid a never-ending loop
-			callback();
-		} else {
-			if (this.isOn === wasOn) {
-				this._log(FILE_ID, `setOn`, `no state change from ${wasOn}`);
-				callback();
-			} else {
-				const newLevel = turnOn ? this.brightness : 0;
-				const reasonExtension = turnOn ? ((this.brightness === 100) ? `on` : `restore`) : `off`;
-
-				this._log(FILE_ID, `setOn`, `changing level to ${newLevel}%`);
-				this.client.setLevel(this.netId, newLevel, () => {
-					callback();
-				}, this.rampDuration / 1000, `setOn (${reasonExtension})`);
-			}
+		if (this.isOn === wasOn) {
+			this._log(FILE_ID, `setOn`, `no state change from ${wasOn}`);
+			return;
 		}
-	}, 50);
-};
 
-CBusLightAccessory.prototype.processClientData = function (err, message) {
-	if (!err) {
-		console.assert(typeof message.level !== `undefined`, `message.level must not be undefined`);
-		const level = message.level;
+		const newLevel = turnOn ? this.brightness : 0;
+		const reasonExtension = turnOn ? ((this.brightness === 100) ? `on` : `restore`) : `off`;
 
-		this.onC10tic.setValue((level > 0) ? 1 : 0, undefined, `event`);
+		this._log(FILE_ID, `setOn`, `changing level to ${newLevel}%`);
+		await new Promise(resolve => this.client.setLevel(
+			this.netId, newLevel, resolve, this.rampDuration / 1000, `setOn (${reasonExtension})`));
 	}
-};
+
+	// received an event over the network -- could have been in response to one of our
+	// commands, or someone else. updateValue() pushes the new state to HomeKit without
+	// re-triggering setOn(), so there's no need for the old context==='event' loop guard.
+	processClientData(err, message) {
+		if (!err) {
+			console.assert(typeof message.level !== `undefined`, `message.level must not be undefined`);
+			this.onCharacteristic.updateValue(message.level > 0);
+		}
+	}
+}
+
+module.exports = CBusLightAccessory;

--- a/accessories/motion-accessory.js
+++ b/accessories/motion-accessory.js
@@ -1,46 +1,34 @@
 'use strict';
 
-let Service;
-let Characteristic;
-let CBusAccessory;
-let uuid;
-
+const CBusAccessory = require('./accessory.js');
 const cbusUtils = require('../lib/cbus-utils.js');
 
 const FILE_ID = cbusUtils.extractIdentifierFromFileName(__filename);
 
-module.exports = function (_service, _characteristic, _accessory, _uuid) {
-	Service = _service;
-	Characteristic = _characteristic;
-	CBusAccessory = _accessory;
-	uuid = _uuid;
+class CBusMotionAccessory extends CBusAccessory {
+	constructor(platform, accessoryData, existingPlatformAccessory) {
+		super(platform, accessoryData, existingPlatformAccessory);
 
-	return CBusMotionAccessory;
-};
+		// register on-off service
+		this.service = this.getService(this.hap.Service.MotionSensor) ||
+			this.addService(this.hap.Service.MotionSensor, this.name);
 
-function CBusMotionAccessory(platform, accessoryData) {
-	//--------------------------------------------------
-	// initialize parent
-	CBusAccessory.call(this, platform, accessoryData);
+		this.service.getCharacteristic(this.hap.Characteristic.MotionDetected)
+			.onGet(this.getMotionState.bind(this));
+	}
 
-	//--------------------------------------------------
-	// register on-off service
-	this.service = this.addService(new Service.MotionSensor(this.name));
-	this.service.getCharacteristic(Characteristic.MotionDetected)
-		.on('get', this.getMotionState.bind(this));
+	async getMotionState() {
+		const message = await new Promise(resolve => this.client.receiveLevel(this.netId, resolve));
+		this._log(FILE_ID, `getState`, message.level);
+		return message.level > 0;
+	}
+
+	processClientData(err, message) {
+		if (!err) {
+			this.service.getCharacteristic(this.hap.Characteristic.MotionDetected)
+				.updateValue(message.level > 0);
+		}
+	}
 }
 
-CBusMotionAccessory.prototype.getMotionState = function (callback) {
-	this.client.receiveLevel(this.netId, message => {
-		this._log(FILE_ID, `getState`, message.level);
-		callback(false, /* state: */ message.level ? 1 : 0);
-	});
-};
-
-CBusMotionAccessory.prototype.processClientData = function (err, message) {
-	if (!err) {
-		const level = message.level;
-		this.service.getCharacteristic(Characteristic.MotionDetected)
-			.setValue((level > 0) ? 1 : 0);
-	}
-};
+module.exports = CBusMotionAccessory;

--- a/accessories/security-accessory.js
+++ b/accessories/security-accessory.js
@@ -1,52 +1,41 @@
 'use strict';
 
-let Service;
-let Characteristic;
-let CBusAccessory;
-let uuid;
-
+const CBusAccessory = require('./accessory.js');
 const cbusUtils = require('../lib/cbus-utils.js');
 
 const FILE_ID = cbusUtils.extractIdentifierFromFileName(__filename);
 
-module.exports = function (_service, _characteristic, _accessory, _uuid) {
-	Service = _service;
-	Characteristic = _characteristic;
-	CBusAccessory = _accessory;
-	uuid = _uuid;
+class CBusSecurityAccessory extends CBusAccessory {
+	constructor(platform, accessoryData, existingPlatformAccessory) {
+		super(platform, accessoryData, existingPlatformAccessory);
 
-	return CBusSecurityAccessory;
-};
+		// register the on-off service
+		this.service = this.getService(this.hap.Service.MotionSensor) ||
+			this.addService(this.hap.Service.MotionSensor, this.name);
 
-function CBusSecurityAccessory(platform, accessoryData) {
-	//--------------------------------------------------
-	// initialize the parent
-	CBusAccessory.call(this, platform, accessoryData);
+		this.service.getCharacteristic(this.hap.Characteristic.MotionDetected)
+			.onGet(this.getMotionState.bind(this));
+	}
 
-	//--------------------------------------------------
-	// register the on-off service
-	this.service = this.addService(new Service.MotionSensor(this.name));
-
-	this.service.getCharacteristic(Characteristic.MotionDetected).on('get', this.getMotionState.bind(this));
-}
-
-CBusSecurityAccessory.prototype.getMotionState = function (callback) {
-	this.client.receiveSecurityStatus(this.id, message => {
+	async getMotionState() {
+		const message = await new Promise(resolve => this.client.receiveSecurityStatus(this.netId, resolve));
 		let detected;
 		if (['zone_unsealed', 'zone_open', 'zone_short'].includes(message.zonestate)) {
-			detected = 1;
+			detected = true;
 		} else if (message.zonestate === 'zone_sealed') {
-			detected = 0;
+			detected = false;
 		}
 
 		this._log(FILE_ID, `getMotionState`, `${message.zonestate} => ${detected}`);
-		callback(false, detected);
-	}, `getMotionState`);
-};
-
-CBusSecurityAccessory.prototype.processClientData = function (err, message) {
-	if (!err) {
-		this.service.getCharacteristic(Characteristic.MotionDetected)
-			.setValue((message.level > 0) ? 1 : 0);
+		return detected;
 	}
-};
+
+	processClientData(err, message) {
+		if (!err) {
+			this.service.getCharacteristic(this.hap.Characteristic.MotionDetected)
+				.updateValue(message.level > 0);
+		}
+	}
+}
+
+module.exports = CBusSecurityAccessory;

--- a/accessories/shutter-accessory.js
+++ b/accessories/shutter-accessory.js
@@ -1,11 +1,7 @@
 'use strict';
 
-let Service;
-let Characteristic;
-let CBusAccessory;
-let uuid;
-
-let cbusUtils = require('../lib/cbus-utils.js');
+const CBusAccessory = require('./accessory.js');
+const cbusUtils = require('../lib/cbus-utils.js');
 
 const FILE_ID = cbusUtils.extractIdentifierFromFileName(__filename);
 
@@ -18,186 +14,164 @@ const SHUTTER_STOP = 2;
 
 const SPIN_TIME = 3000;
 
-module.exports = function (_service, _characteristic, _accessory, _uuid) {
-	Service = _service;
-	Characteristic = _characteristic;
-	CBusAccessory = _accessory;
-	uuid = _uuid;
+class CBusShutterAccessory extends CBusAccessory {
+	constructor(platform, accessoryData, existingPlatformAccessory) {
+		super(platform, accessoryData, existingPlatformAccessory);
 
-	return CBusShutterAccessory;
-};
+		// handle inversion
+		this.invert = (accessoryData.invert === true) || (accessoryData.invert === 'true');
 
-function CBusShutterAccessory(platform, accessoryData) {
-	//--------------------------------------------------
-	// initialize the parent
-	CBusAccessory.call(this, platform, accessoryData);
+		// prime the last known position of the blinds
+		// assume the blinds were closed, but as soon as we can issue a receiveLightStatus to see
+		// if we can infer the position from the shutter state
+		this.cachedTargetPosition = 0;
 
-	//--------------------------------------------------
-	// state variables
-	// handle inversion
-	this.invert = accessoryData.invert || 'false';
+		setTimeout(() => {
+			this._log(FILE_ID, `construct`, `prime state`);
+			this.client.receiveLevel(this.netId, message => {
+				const translated = this.translateShutterToProportional(message.level);
 
-	// prime the last known position of the blinds
-	// assume the blinds were closed, but as soon as we can issue a receiveLightStatus to see
-	// if we can infer the position from the shutter state
-	this.cachedTargetPosition = 0;
+				if (typeof translated === `undefined`) {
+					// TODO be smarter here
+					this._log(FILE_ID, `prime`, `position indeterminate (${message.level}%); defaulting to 0%`);
+					this.cachedTargetPosition = 0;
+				} else {
+					this._log(FILE_ID, `prime`, `cachedTargetPosition = ${translated}%`);
+					this.cachedTargetPosition = translated;
+				}
+			});
+		}, 5000);
 
-	setTimeout(() => {
-		this._log(FILE_ID, `construct`, `prime state`);
-		this.client.receiveLevel(this.netId, message => {
-			let translated = this.translateShutterToProportional(message.level);
+		// register the Window Covering service
+		this.service = this.getService(this.hap.Service.WindowCovering) ||
+			this.addService(this.hap.Service.WindowCovering, this.name);
 
-			if (typeof translated === `undefined`) {
-				// TODO be smarter here
-				this._log(FILE_ID, `prime`, `position indeterminate (${message.level}%); defaulting to 0%`);
-				this.cachedTargetPosition = 0;
-			} else {
-				this._log(FILE_ID, `prime`, `cachedTargetPosition = ${translated}%`);
-				this.cachedTargetPosition = translated;
-			}
-		});
-	}, 5000);
+		// the current position (0-100%)
+		this.service.getCharacteristic(this.hap.Characteristic.CurrentPosition)
+			.onGet(this.getCurrentPosition.bind(this));
 
-	//--------------------------------------------------
-	// register the Window Covering service
-	this.service = this.addService(new Service.WindowCovering(this.name));
+		// the target position (0-100%)
+		this.service.getCharacteristic(this.hap.Characteristic.TargetPosition)
+			.onGet(this.getTargetPosition.bind(this))
+			.onSet(this.setTargetPosition.bind(this));
 
-	// the current position (0-100%)
-	// https://github.com/KhaosT/HAP-NodeJS/blob/master/lib/gen/HomeKitTypes.js#L3211
-	this.service.getCharacteristic(Characteristic.CurrentPosition)
-		.on('get', this.getCurrentPosition.bind(this));
-
-	// the target position (0-100%)
-	// https://github.com/KhaosT/HAP-NodeJS/blob/master/lib/gen/HomeKitTypes.js#L3212
-	this.service.getCharacteristic(Characteristic.TargetPosition)
-		.on('get', this.getTargetPosition.bind(this))
-		.on('set', this.setTargetPosition.bind(this));
-
-	// the position state
-	// 0 = DECREASING; 1 = INCREASING; 2 = STOPPED;
-	// https://github.com/KhaosT/HAP-NodeJS/blob/master/lib/gen/HomeKitTypes.js#L3213
-	this.service.getCharacteristic(Characteristic.PositionState)
-		.on('get', this.getPositionState.bind(this));
-}
-
-CBusShutterAccessory.prototype.translateProportionalToShutter = function (level) {
-	if ((level > 100) || (level < 0)) {
-		this._log(FILE_ID, `translate`, `illegal level: ${level}`);
-		return 0;
+		// the position state: 0 = DECREASING; 1 = INCREASING; 2 = STOPPED
+		this.service.getCharacteristic(this.hap.Characteristic.PositionState)
+			.onGet(this.getPositionState.bind(this));
 	}
 
-	// invert if required
-	if (this.invert === 'true') {
-		const invertedLevel = 100 - level;
-		this._log(FILE_ID, `translate`, `${level} inverted to ${invertedLevel}%`);
-		level = invertedLevel;
+	translateProportionalToShutter(level) {
+		if ((level > 100) || (level < 0)) {
+			this._log(FILE_ID, `translate`, `illegal level: ${level}`);
+			return 0;
+		}
+
+		// invert if required
+		if (this.invert) {
+			const invertedLevel = 100 - level;
+			this._log(FILE_ID, `translate`, `${level} inverted to ${invertedLevel}%`);
+			level = invertedLevel;
+		}
+
+		// in level translation mode, the levels 1, 2, 98, 99 have special meanings and should
+		// therefore be mapped out to the values for open (100%) and closed (0%)
+		let translated;
+
+		switch (level) {
+			case 0:
+			case 1:
+			case 2:
+				translated = 0;
+				break;
+
+			case 98:
+			case 99:
+			case 100:
+				translated = 100;
+				break;
+
+			default:
+				translated = level;
+				break;
+		}
+
+		return translated;
 	}
 
-	// in level translation mode, the levels 1, 2, 98, 99 have special meanings and should
-	// therefore be mapped out to the vales for open (100%) and closed (0%)
-	let translated;
+	translateShutterToProportional(level) {
+		if (typeof level === `undefined`) {
+			return undefined;
+		}
 
-	switch (level) {
-		case 0:
-		case 1:
-		case 2:
-			translated = 0;
-			break;
+		if ((level > 100) || (level < 0)) {
+			this._log(FILE_ID, `translate`, `illegal network level = ${level}`);
+			return undefined;
+		}
 
-		case 98:
-		case 99:
-		case 100:
-			translated = 100;
-			break;
+		let translated;
+		switch (level) {
+			case SHUTTER_OPEN:
+				translated = 100;
+				break;
 
-		default:
-			translated = level;
-			break;
+			case SHUTTER_DOWN:
+				translated = 0;
+				break;
+
+			case SHUTTER_TOGGLE:
+			case SHUTTER_OPEN_TOGGLE:
+			case SHUTTER_CLOSE_TOGGLE:
+			case SHUTTER_STOP:
+				// could be a bit smarter here
+				translated = undefined;
+				break;
+
+			default:
+				translated = level;
+				break;
+		}
+
+		// invert if required
+		if ((typeof translated !== `undefined`) && this.invert) {
+			const invertedLevel = 100 - level;
+			this._log(FILE_ID, `translate`, `${level}% inverted to ${invertedLevel}%`);
+			translated = invertedLevel;
+		}
+
+		return translated;
 	}
 
-	return translated;
-};
-
-CBusShutterAccessory.prototype.translateShutterToProportional = function (level) {
-	if (typeof level === undefined) {
-		return undefined;
+	getCurrentPosition() {
+		this._log(FILE_ID, `getCurrentPosition`, this.cachedTargetPosition);
+		return this.cachedTargetPosition;
 	}
 
-	if ((level > 100) || (level < 0)) {
-		this._log(FILE_ID, `translate`, `illegal network level = ${level}`);
-		return undefined;
+	getPositionState() {
+		// unless/until we simulate the shutter relay, we don't know whether it is moving
+		// so assume that it is stopped
+		const currentPositionState = this.hap.Characteristic.PositionState.STOPPED;
+
+		this._log(FILE_ID, `getPositionState`, currentPositionState);
+		return currentPositionState;
 	}
 
-	let translated;
-	switch (level) {
-		case SHUTTER_OPEN:
-			translated = 100;
-			break;
-
-		case SHUTTER_DOWN:
-			translated = 0;
-			break;
-
-		case SHUTTER_TOGGLE:
-		case SHUTTER_OPEN_TOGGLE:
-		case SHUTTER_CLOSE_TOGGLE:
-		case SHUTTER_STOP:
-			// could be a bit smarter here
-			translated = undefined;
-			break;
-
-		default:
-			translated = level;
-			break;
-	}
-
-	// invert if required
-	if ((typeof translated !== `undefined`) && (this.invert === true)) {
-		let invertedLevel = 100 - level;
-		this._log(FILE_ID, `translate`, `${level}% inverted to ${invertedLevel}%`);
-		translated = invertedLevel;
-	}
-
-	return translated;
-};
-
-CBusShutterAccessory.prototype.getCurrentPosition = function (callback) {
-	this._log(FILE_ID, `getCurrentPosition`, this.cachedTargetPosition);
-	callback(false, /* value */ this.cachedTargetPosition);
-};
-
-CBusShutterAccessory.prototype.getPositionState = function (callback) {
-	// unless/until we simulate the shutter relay, we don't know whether it is moving
-	// so assume that it is stopped
-	const currentPositionState = Characteristic.PositionState.STOPPED;
-
-	this._log(FILE_ID, `getPositionState`, currentPositionState);
-	callback(false, currentPositionState);
-};
-
-CBusShutterAccessory.prototype.getTargetPosition = function (callback) {
-	this.client.receiveLevel(this.netId, result => {
-		let proportion = this.translateShutterToProportional(result.level);
+	async getTargetPosition() {
+		const result = await new Promise(resolve => this.client.receiveLevel(this.netId, resolve));
+		const proportion = this.translateShutterToProportional(result.level);
 		this._log(FILE_ID, `getTargetPosition`, proportion);
 
 		if (typeof proportion === `undefined`) {
 			// TODO be smarter here
 			this._log(FILE_ID, `getTargetPosition`, `indeterminate; defaulting to 0%`);
-			callback(false, 0);
-		} else {
-			// cache a copy
-			this.cachedTargetPosition = proportion;
-			callback(false, proportion);
+			return 0;
 		}
-	});
-};
 
-CBusShutterAccessory.prototype.setTargetPosition = function (newPosition, callback, context) {
-	// context helps us avoid a never-ending loop
-	if (context === `event`) {
-		// this._log(FILE_ID, 'suppressing remote setTargetPosition');
-		callback();
-	} else {
+		// cache a copy
+		this.cachedTargetPosition = proportion;
+		return proportion;
+	}
+
+	async setTargetPosition(newPosition) {
 		this._log(FILE_ID, `setTargetPosition`, `${newPosition} (was ${this.cachedTargetPosition})`);
 
 		// tell homekit that the window covering is moving
@@ -207,74 +181,73 @@ CBusShutterAccessory.prototype.setTargetPosition = function (newPosition, callba
 
 		if (newPosition > this.cachedTargetPosition) {
 			this._log(FILE_ID, `setTargetPosition`, `moving up`);
-			direction = Characteristic.PositionState.INCREASING;
+			direction = this.hap.Characteristic.PositionState.INCREASING;
 			interimPosition = newPosition - 1;
 		} else if (newPosition < this.cachedTargetPosition) {
 			this._log(FILE_ID, `setTargetPosition`, `moving down`);
-			direction = Characteristic.PositionState.DECREASING;
+			direction = this.hap.Characteristic.PositionState.DECREASING;
 			interimPosition = newPosition + 1;
 		} else {
 			this._log(FILE_ID, `setTargetPosition`, `moving nowhere`);
-			direction = Characteristic.PositionState.STOPPED;
+			direction = this.hap.Characteristic.PositionState.STOPPED;
 		}
 
-		if (direction !== Characteristic.PositionState.STOPPED) {
+		if (direction !== this.hap.Characteristic.PositionState.STOPPED) {
 			// immediately set the state to look like we're almost there
 			this._log(FILE_ID, `setTargetPosition`, `interim position = ${interimPosition} (was ${this.cachedTargetPosition})`);
 			this.cachedTargetPosition = interimPosition;
-			this.service.setCharacteristic(Characteristic.PositionState, direction);
-			this.service.setCharacteristic(Characteristic.CurrentPosition, interimPosition);
+			this.service.updateCharacteristic(this.hap.Characteristic.PositionState, direction);
+			this.service.updateCharacteristic(this.hap.Characteristic.CurrentPosition, interimPosition);
 		}
 
 		// set up move to new shutter level
-		let shutterLevel = this.translateProportionalToShutter(newPosition);
+		const shutterLevel = this.translateProportionalToShutter(newPosition);
 
 		// in this framework, the shutter relay position just looks like the brightness of a light
-		this.client.setLevel(this.netId, shutterLevel, () => {
-			this._log(FILE_ID, `setTargetPosition`, 'sent to client: shutter = ' + shutterLevel);
+		await new Promise(resolve => this.client.setLevel(this.netId, shutterLevel, resolve));
+		this._log(FILE_ID, `setTargetPosition`, `sent to client: shutter = ${shutterLevel}`);
 
-			// keep the spinner moving for a little while to give the sense of movement
-			setTimeout(() => {
-				this.cachedTargetPosition = newPosition;
-				this._log(FILE_ID, `setTargetPosition`, `finishing movement; signalling stopping at ${this.cachedTargetPosition}`);
-				this.service.setCharacteristic(Characteristic.CurrentPosition, this.cachedTargetPosition);
-				this.service.setCharacteristic(Characteristic.PositionState, Characteristic.PositionState.STOPPED);
-			}, SPIN_TIME);
-
-			callback();
-		});
+		// keep the spinner moving for a little while to give the sense of movement
+		setTimeout(() => {
+			this.cachedTargetPosition = newPosition;
+			this._log(FILE_ID, `setTargetPosition`, `finishing movement; signalling stopping at ${this.cachedTargetPosition}`);
+			this.service.updateCharacteristic(this.hap.Characteristic.CurrentPosition, this.cachedTargetPosition);
+			this.service.updateCharacteristic(this.hap.Characteristic.PositionState, this.hap.Characteristic.PositionState.STOPPED);
+		}, SPIN_TIME);
 	}
-};
 
-CBusShutterAccessory.prototype.processClientData = function (err, message) {
-	if (!err) {
-		const level = message.level;
-		const translated = this.translateShutterToProportional(level);
+	processClientData(err, message) {
+		if (err) {
+			return;
+		}
+
+		const translated = this.translateShutterToProportional(message.level);
 
 		if (typeof translated === `undefined`) {
 			this._log(FILE_ID, `processClientData`, `indeterminate`);
-
 			// could be a bit smarter here
 			this.cachedTargetPosition = 0;
-		} else {
-			this._log(FILE_ID, `processClientData`, `received ${translated}%`);
+			return;
+		}
 
-			if (this.cachedTargetPosition !== translated) {
-				this.service.getCharacteristic(Characteristic.TargetPosition).setValue(translated, undefined, `event`);
+		this._log(FILE_ID, `processClientData`, `received ${translated}%`);
 
-				//  move over 2 seconds
-				setTimeout(() => {
-					this.cachedTargetPosition = translated;
+		if (this.cachedTargetPosition !== translated) {
+			this.service.getCharacteristic(this.hap.Characteristic.TargetPosition).updateValue(translated);
 
-					// in many cases the shutter will still be travelling for a while, but unless/until we
-					// simulate the shutter relay, we won't know when it has stopped.
-					// so just assume it gets there immediately.
-					this.service.getCharacteristic(Characteristic.CurrentPosition)
-						.setValue(this.cachedTargetPosition, undefined, `event`);
-					this.service.getCharacteristic(Characteristic.PositionState)
-						.setValue(Characteristic.PositionState.STOPPED, undefined, `event`);
-				}, SPIN_TIME);
-			}
+			// move over a couple of seconds
+			setTimeout(() => {
+				this.cachedTargetPosition = translated;
+
+				// in many cases the shutter will still be travelling for a while, but unless/until we
+				// simulate the shutter relay, we won't know when it has stopped.
+				// so just assume it gets there immediately.
+				this.service.getCharacteristic(this.hap.Characteristic.CurrentPosition).updateValue(this.cachedTargetPosition);
+				this.service.getCharacteristic(this.hap.Characteristic.PositionState)
+					.updateValue(this.hap.Characteristic.PositionState.STOPPED);
+			}, SPIN_TIME);
 		}
 	}
-};
+}
+
+module.exports = CBusShutterAccessory;

--- a/accessories/smoke-sensor-accessory.js
+++ b/accessories/smoke-sensor-accessory.js
@@ -1,48 +1,34 @@
 'use strict';
 
-let Service;
-let Characteristic;
-let CBusAccessory;
-let uuid;
-
+const CBusAccessory = require('./accessory.js');
 const cbusUtils = require('../lib/cbus-utils.js');
 
 const FILE_ID = cbusUtils.extractIdentifierFromFileName(__filename);
 
-module.exports = function (_service, _characteristic, _accessory, _uuid) {
-	Service = _service;
-	Characteristic = _characteristic;
-	CBusAccessory = _accessory;
-	uuid = _uuid;
+class CBusSmokeAccessory extends CBusAccessory {
+	constructor(platform, accessoryData, existingPlatformAccessory) {
+		super(platform, accessoryData, existingPlatformAccessory);
 
-	return CBusSmokeAccessory;
-};
+		// register on-off service
+		this.service = this.getService(this.hap.Service.SmokeSensor) ||
+			this.addService(this.hap.Service.SmokeSensor, this.name);
 
-function CBusSmokeAccessory(platform, accessoryData) {
-	//--------------------------------------------------
-	// initialize parent
-	CBusAccessory.call(this, platform, accessoryData);
-
-	//--------------------------------------------------
-	// register on-off service
-    this.service = this.addService(new Service.SmokeSensor(this.name));
-    this.service.getCharacteristic(Characteristic.SmokeDetected)
-        .on('get', this.getMotionState.bind(this));
-    
-    }
-
-CBusSmokeAccessory.prototype.getMotionState = function (callback) {
-	this.client.receiveLevel(this.netId, message => {
-		this._log(FILE_ID, `getState`, message.level);
-		callback(false, /* state: */ message.level ? 1 : 0);
-	});
-};
-
-CBusSmokeAccessory.prototype.processClientData = function (err, message) {
-	if (!err) {
-        const level = message.level;
-        this.service.getCharacteristic(Characteristic.SmokeDetected)
-            .setValue((level > 0) ? 1 : 0);
-
+		this.service.getCharacteristic(this.hap.Characteristic.SmokeDetected)
+			.onGet(this.getMotionState.bind(this));
 	}
-};
+
+	async getMotionState() {
+		const message = await new Promise(resolve => this.client.receiveLevel(this.netId, resolve));
+		this._log(FILE_ID, `getState`, message.level);
+		return message.level > 0;
+	}
+
+	processClientData(err, message) {
+		if (!err) {
+			this.service.getCharacteristic(this.hap.Characteristic.SmokeDetected)
+				.updateValue(message.level > 0);
+		}
+	}
+}
+
+module.exports = CBusSmokeAccessory;

--- a/accessories/switch-accessory.js
+++ b/accessories/switch-accessory.js
@@ -1,101 +1,82 @@
 'use strict';
 
-let Service;
-let Characteristic;
-let CBusAccessory;
-let uuid;
-
-const chalk = require('chalk');
-
 const ms = require('ms');
 
+const CBusAccessory = require('./accessory.js');
 const cbusUtils = require('../lib/cbus-utils.js');
 
 const FILE_ID = cbusUtils.extractIdentifierFromFileName(__filename);
 
-module.exports = function (_service, _characteristic, _accessory, _uuid) {
-	Service = _service;
-	Characteristic = _characteristic;
-	CBusAccessory = _accessory;
-	uuid = _uuid;
+class CBusSwitchAccessory extends CBusAccessory {
+	constructor(platform, accessoryData, existingPlatformAccessory) {
+		super(platform, accessoryData, existingPlatformAccessory);
 
-	return CBusSwitchAccessory;
-};
+		// if we have an activeDuration specified, stash it away
+		if (typeof accessoryData.activeDuration !== `undefined`) {
+			this.activeDuration = ms(accessoryData.activeDuration);
+			this._log(FILE_ID, `construct`, `automatically turn off ${this.activeDuration}ms when activated via homebridge`);
+		}
 
-function CBusSwitchAccessory(platform, accessoryData) {
-	// initialize the parent
-	CBusAccessory.call(this, platform, accessoryData);
+		this.isOn = false;
 
-	// if we have an activeDuration specified, stash it away
-	if (typeof accessoryData.activeDuration !== `undefined`) {
-		this.activeDuration = ms(accessoryData.activeDuration);
-		this._log(FILE_ID, `construct`, `automatically turn off ${this.activeDuration}ms when activated via homebridge`);
+		// register the on-off service
+		this.service = this.getService(this.hap.Service.Switch) ||
+			this.addService(this.hap.Service.Switch, this.name);
+
+		this.onCharacteristic = this.service.getCharacteristic(this.hap.Characteristic.On);
+		this.onCharacteristic
+			.onGet(this.getOn.bind(this))
+			.onSet(this.setOn.bind(this));
 	}
 
-	// TODO do we need to prime this?
-	this.isOn = false;
-
-	// register the on-off service
-	this.service = this.addService(new Service.Switch(this.name));
-	this.service.getCharacteristic(Characteristic.On)
-		.on('get', this.getOn.bind(this))
-		.on('set', this.setOn.bind(this));
-}
-
-CBusSwitchAccessory.prototype.getOn = function (callback) {
-	this.client.receiveLevel(this.netId, message => {
+	async getOn() {
+		const message = await new Promise(resolve => this.client.receiveLevel(this.netId, resolve, `getOn`));
 		this.isOn = message.level > 0;
 		this._log(FILE_ID, `getOn`, `status = '${this.isOn ? `on` : `off`}'`);
-		callback(false, this.isOn ? 1 : 0);
-	}, `getOn`);
-};
+		return this.isOn;
+	}
 
-CBusSwitchAccessory.prototype.setOn = function (turnOn, callback, context) {
-	if (context === `event`) {
-		// context helps us avoid a never-ending loop
-		callback();
-	} else {
+	async setOn(turnOn) {
+		if (this.timeout) {
+			this._log(FILE_ID, `setOn`, `clearing activity timer`);
+			clearTimeout(this.timeout);
+			this.timeout = undefined;
+		}
+
 		console.assert((turnOn === 1) || (turnOn === 0) || (turnOn === true) || (turnOn === false));
 		const wasOn = this.isOn;
 		this.isOn = (turnOn === 1) || (turnOn === true);
 
 		if (wasOn === this.isOn) {
 			this._log(FILE_ID, `setOn`, `no state change from ${turnOn}`);
-			callback();
-		} else if (turnOn) {
+			return;
+		}
+
+		if (this.isOn) {
 			this._log(FILE_ID, `setOn(true)`, `changing to 'on'`);
-			this.client.turnOn(this.netId, () => {
-				if (this.activeDuration) {
-					this.timeout = setTimeout(() => {
-						this._log(FILE_ID, `activity timer expired`, `turning off`);
-						this.isOn = false;
-						this.client.turnOff(this.netId);
-					}, this.activeDuration);
-					this._log(FILE_ID, `activity timer activated`, `will turn off in ${ms(this.activeDuration)} (${this.activeDuration}ms)`);
-				}
-				callback();
-			});
+			await new Promise(resolve => this.client.turnOn(this.netId, resolve));
+
+			if (this.activeDuration) {
+				this.timeout = setTimeout(() => {
+					this._log(FILE_ID, `activity timer expired`, `turning off`);
+					this.isOn = false;
+					this.onCharacteristic.updateValue(false);
+					this.client.turnOff(this.netId);
+				}, this.activeDuration);
+				this._log(FILE_ID, `activity timer activated`, `will turn off in ${ms(this.activeDuration)} (${this.activeDuration}ms)`);
+			}
 		} else {
-			// turnOn === false, ie. turn off
 			this._log(FILE_ID, `setOn(false)`, `changing to 'off'`);
-			this.client.turnOff(this.netId, () => {
-				callback();
-			});
+			await new Promise(resolve => this.client.turnOff(this.netId, resolve));
 		}
 	}
 
-	// if we turn off (regardless of whether by homebridge or cbus), clear out any timeout
-	if (!turnOn && this.timeout) {
-		this._log(FILE_ID, `turned off`, `clearing activity timer`);
-		clearTimeout(this.timeout);
+	processClientData(err, message) {
+		if (!err) {
+			console.assert(typeof message.level !== `undefined`, `message.level must be defined`);
+			this.onCharacteristic.updateValue(message.level > 0);
+		}
 	}
-};
+}
 
-CBusSwitchAccessory.prototype.processClientData = function (err, message) {
-	if (!err) {
-		console.assert(typeof message.level !== `undefined`, `message.level must be defined`);
-		const level = message.level;
-
-		this.service.getCharacteristic(Characteristic.On).setValue((level > 0) ? 1 : 0, undefined, `event`);
-	}
-};
+module.exports = CBusSwitchAccessory;

--- a/accessories/temperature-accessory.js
+++ b/accessories/temperature-accessory.js
@@ -1,45 +1,35 @@
 'use strict';
 
-let Service;
-let Characteristic;
-let CBusAccessory;
-let uuid;
-
+const CBusAccessory = require('./accessory.js');
 const cbusUtils = require('../lib/cbus-utils.js');
 
 const FILE_ID = cbusUtils.extractIdentifierFromFileName(__filename);
 
-module.exports = function (_service, _characteristic, _accessory, _uuid) {
-	Service = _service;
-	Characteristic = _characteristic;
-	CBusAccessory = _accessory;
-	uuid = _uuid;
+class CBusTemperatureAccessory extends CBusAccessory {
+	constructor(platform, accessoryData, existingPlatformAccessory) {
+		super(platform, accessoryData, existingPlatformAccessory);
 
-	return CBusTemperatureAccessory;
-};
-
-function CBusTemperatureAccessory(platform, accessoryData) {
-	//--------------------------------------------------
-	// initialize parent
-	CBusAccessory.call(this, platform, accessoryData);
-
-	//--------------------------------------------------
-	// register temperature service
-    this.service = this.addService(new Service.TemperatureSensor(this.name));
-};
-
-CBusTemperatureAccessory.prototype.processClientData = function (err, message) {
-	const currentTemp = message.remainder &&
-		message.remainder.length >= 4 &&
-		Number(message.remainder[1]) * Math.pow(10, Number(message.remainder[2]));
-	const temperatureDisplayUnits = message.remainder &&
-		message.remainder.length >= 4 &&
-		Number(message.remainder[3]);
-	if (!err) {
-		this._log(FILE_ID, `${message.application} event`, currentTemp);
-        this.service.getCharacteristic(Characteristic.CurrentTemperature)
-			.setValue(currentTemp);
-		this.service.getCharacteristic(Characteristic.TemperatureDisplayUnits)
-			.setValue(temperatureDisplayUnits);
+		// register temperature service
+		this.service = this.getService(this.hap.Service.TemperatureSensor) ||
+			this.addService(this.hap.Service.TemperatureSensor, this.name);
 	}
-};
+
+	processClientData(err, message) {
+		const currentTemp = message.remainder &&
+			message.remainder.length >= 4 &&
+			Number(message.remainder[1]) * Math.pow(10, Number(message.remainder[2]));
+		const temperatureDisplayUnits = message.remainder &&
+			message.remainder.length >= 4 &&
+			Number(message.remainder[3]);
+
+		if (!err) {
+			this._log(FILE_ID, `${message.application} event`, currentTemp);
+			this.service.getCharacteristic(this.hap.Characteristic.CurrentTemperature)
+				.updateValue(currentTemp);
+			this.service.getCharacteristic(this.hap.Characteristic.TemperatureDisplayUnits)
+				.updateValue(temperatureDisplayUnits);
+		}
+	}
+}
+
+module.exports = CBusTemperatureAccessory;

--- a/accessories/trigger-accessory.js
+++ b/accessories/trigger-accessory.js
@@ -1,62 +1,44 @@
 'use strict';
 
-let Service;
-let Characteristic;
-let CBusAccessory;
-let uuid;
-
-const chalk = require('chalk');
-
-const ms = require('ms');
-
+const CBusAccessory = require('./accessory.js');
 const cbusUtils = require('../lib/cbus-utils.js');
 
 const FILE_ID = cbusUtils.extractIdentifierFromFileName(__filename);
 
-module.exports = function (_service, _characteristic, _accessory, _uuid) {
-	Service = _service;
-	Characteristic = _characteristic;
-	CBusAccessory = _accessory;
-	uuid = _uuid;
+class CBusTriggerAccessory extends CBusAccessory {
+	constructor(platform, accessoryData, existingPlatformAccessory) {
+		super(platform, accessoryData, existingPlatformAccessory);
 
-	return CBusTriggerAccessory;
-};
+		try {
+			this.action = cbusUtils.integerise(accessoryData.action);
+		} catch (err) {
+			throw new Error(`action value '${accessoryData.action}' for accessory '${this.name}' is not an integer`);
+		}
 
-function CBusTriggerAccessory(platform, accessoryData) {
-	// initialize the parent
-	CBusAccessory.call(this, platform, accessoryData);
+		// register the on-off service
+		this.service = this.getService(this.hap.Service.Switch) ||
+			this.addService(this.hap.Service.Switch, this.name);
 
-	try {
-		this.action = cbusUtils.integerise(accessoryData.action);
-	} catch (err) {
-		throw new Error(`action value '${accessoryData.action}' for accessory '${this.name} is not an integer`);
+		this.onCharacteristic = this.service.getCharacteristic(this.hap.Characteristic.On);
+		this.onCharacteristic.onSet(this.setTrigger.bind(this));
 	}
 
-	// register the on-off service
-	this.service = this.addService(new Service.Switch(this.name));
-	this.service.getCharacteristic(Characteristic.On)
-		.on('set', this.setTrigger.bind(this));
+	async setTrigger(trigger) {
+		console.assert((trigger === 1) || (trigger === 0) || (trigger === true) || (trigger === false));
+
+		if (trigger) {
+			await new Promise(resolve => this.client.triggerAction(this.netId, this.action, resolve));
+			this.timeout = setTimeout(() => {
+				this.onCharacteristic.updateValue(false);
+			}, 500);
+		}
+	}
+
+	processClientData(err, message) {
+		if (!err) {
+			console.assert(typeof message.level !== `undefined`, `message.level must be defined`);
+		}
+	}
 }
 
-CBusTriggerAccessory.prototype.setTrigger = function (trigger, callback, context) {
-	if (context === `event`) {
-		// context helps us avoid a never-ending loop
-		callback();
-	} else {
-		console.assert((trigger === 1) || (trigger === 0) || (trigger === true) || (trigger === false));
-		if (trigger) {
-			this.client.triggerAction(this.netId, this.action, () => {
-				this.timeout = setTimeout(() => {
-					this.service.getCharacteristic(Characteristic.On).setValue(0);
-				}, 500);
-			});		
-		}
-		callback();
-	}
-};
-
-CBusTriggerAccessory.prototype.processClientData = function (err, message) {
-	if (!err) {
-		console.assert(typeof message.level !== `undefined`, `message.level must be defined`);
-	}
-};
+module.exports = CBusTriggerAccessory;

--- a/index.js
+++ b/index.js
@@ -1,234 +1,225 @@
 'use strict';
 
 require('./hot-debug.js');
-const log = require('debug')('cbus:platform');
+const debug = require('debug')('cbus:platform');
 const logLevel = require('debug')('cbus:level');
 const logClient = require('debug')('cbus:client');
 
 const chalk = require('chalk');
 
-const CGateClient = require(`./lib/cgate-client.js`);
-const CGateDatabase = require(`./lib/cgate-database.js`);
-const CGateExport = require(`./lib/cgate-export.js`);
+const CGateClient = require('./lib/cgate-client.js');
+const CGateDatabase = require('./lib/cgate-database.js');
+const CGateExport = require('./lib/cgate-export.js');
 
-const CBusNetId = require(`./lib/cbus-netid.js`);
-const cbusUtils = require(`./lib/cbus-utils.js`);
+const CBusNetId = require('./lib/cbus-netid.js');
+const CBusAccessory = require('./accessories/accessory.js');
+
+const PLUGIN_NAME = 'homebridge-cbus';
+const PLATFORM_NAME = 'CBus';
+
+// maps config.json accessory 'type' values to their implementation class
+const ACCESSORY_TYPES = {
+	light: require('./accessories/light-accessory.js'),
+	dimmer: require('./accessories/dimmer-accessory.js'),
+	motion: require('./accessories/motion-accessory.js'),
+	security: require('./accessories/security-accessory.js'),
+	shutter: require('./accessories/shutter-accessory.js'),
+	fan: require('./accessories/fan-accessory.js'),
+	switch: require('./accessories/switch-accessory.js'),
+	trigger: require('./accessories/trigger-accessory.js'),
+	smoke: require('./accessories/smoke-sensor-accessory.js'),
+	contact: require('./accessories/contact-accessory.js'),
+	temperature: require('./accessories/temperature-accessory.js'),
+};
 
 // ==========================================================================================
 // Exports block
 // ==========================================================================================
 
-module.exports = function (homebridge) {
-	// globals
-	const Service = homebridge.hap.Service;
-	const Characteristic = homebridge.hap.Characteristic;
-	const Accessory = homebridge.hap.Accessory;
-	const uuid = homebridge.hap.uuid;
-
-	// load accessories
-	const CBusAccessory = require('./accessories/accessory.js')(Service, Characteristic, Accessory, uuid);
-	const CBusLightAccessory = require('./accessories/light-accessory.js')(Service, Characteristic, CBusAccessory, uuid);
-	const CBusDimmerAccessory = require('./accessories/dimmer-accessory.js')(Service, Characteristic, CBusLightAccessory, uuid);
-	const CBusMotionAccessory = require('./accessories/motion-accessory.js')(Service, Characteristic, CBusAccessory, uuid);
-	const CBusSecurityAccessory = require('./accessories/security-accessory.js')(Service, Characteristic, CBusAccessory, uuid);
-	const CBusShutterAccessory = require('./accessories/shutter-accessory.js')(Service, Characteristic, CBusAccessory, uuid);
-	const CBusFanAccessory = require('./accessories/fan-accessory.js')(Service, Characteristic, CBusAccessory, uuid);
-	const CBusSwitchAccessory = require('./accessories/switch-accessory.js')(Service, Characteristic, CBusAccessory, uuid);
-	const CBusTriggerAccessory = require('./accessories/trigger-accessory.js')(Service, Characteristic, CBusAccessory, uuid);
-  const CBusSmokeAccessory = require('./accessories/smoke-sensor-accessory.js')(Service, Characteristic, CBusAccessory, uuid);
-	const CBusContactAccessory = require('./accessories/contact-accessory.js')(Service, Characteristic, CBusAccessory, uuid);
-	const CBusTemperatureAccessory = require('./accessories/temperature-accessory.js')(Service, Characteristic, CBusAccessory, uuid);
-	
-	// fix inheritance, since we've loaded our classes before the Accessory class has been loaded
-	cbusUtils.fixInheritance(CBusAccessory, Accessory);
-	cbusUtils.fixInheritance(CBusLightAccessory, CBusAccessory);
-	cbusUtils.fixInheritance(CBusDimmerAccessory, CBusLightAccessory);
-	cbusUtils.fixInheritance(CBusMotionAccessory, CBusAccessory);
-	cbusUtils.fixInheritance(CBusSecurityAccessory, CBusAccessory);
-	cbusUtils.fixInheritance(CBusShutterAccessory, CBusAccessory);
-	cbusUtils.fixInheritance(CBusFanAccessory, CBusAccessory);
-	cbusUtils.fixInheritance(CBusSwitchAccessory, CBusAccessory);
-	cbusUtils.fixInheritance(CBusTriggerAccessory, CBusAccessory);
-  cbusUtils.fixInheritance(CBusSmokeAccessory, CBusAccessory);
-	cbusUtils.fixInheritance(CBusContactAccessory, CBusAccessory);
-	cbusUtils.fixInheritance(CBusTemperatureAccessory, CBusAccessory);
-	
-	// register ourself with homebridge
-	homebridge.registerPlatform('homebridge-cbus', 'CBus', CBusPlatform);
-
-	// build the accessory definition map
-	module.exports.accessoryDefinitions = {
-		light: CBusLightAccessory,
-		dimmer: CBusDimmerAccessory,
-		motion: CBusMotionAccessory,
-		security: CBusSecurityAccessory,
-		shutter: CBusShutterAccessory,
-		fan: CBusFanAccessory,
-		switch: CBusSwitchAccessory,
-		trigger: CBusTriggerAccessory,
-    smoke: CBusSmokeAccessory,
-		contact: CBusContactAccessory,
-		temperature: CBusTemperatureAccessory,
-	};
+module.exports = (api) => {
+	api.registerPlatform(PLUGIN_NAME, PLATFORM_NAME, CBusPlatform);
 };
 
 // ==========================================================================================
 // CBusPlatform
 // ==========================================================================================
+//
+// This is a homebridge "dynamic platform": accessories are wrapped in a homebridge
+// PlatformAccessory, cached to disk between restarts, and registered/unregistered via
+// api.registerPlatformAccessories()/unregisterPlatformAccessories(). This replaces the old
+// "static platform" accessories(callback) style, which Homebridge's modern versions have
+// moved away from, and which required each accessory to directly subclass hap-nodejs's
+// Accessory class -- something that no longer works now that Accessory is a real ES6 class.
 
-function CBusPlatform(ignoredLog, config) {
-	// stash vars
-	this.config = config;
+class CBusPlatform {
+	constructor(log, config, api) {
+		this.log = log;
+		this.config = config || {};
+		this.api = api;
+		this.hap = api.hap;
 
-	this.registeredAccessories = undefined;
-	this.client = undefined;
-	this.database = undefined;
+		// PlatformAccessory instances restored from homebridge's on-disk cache, keyed by UUID.
+		// Populated by configureAccessory() before didFinishLaunching fires.
+		this.cachedAccessories = new Map();
 
-	// client IP and port
-	if (typeof config.client_ip_address === `undefined`) {
-		log('client IP address missing');
-		process.exit(1);
+		// our accessory wrapper instances, keyed by netId string, so incoming C-Gate events
+		// can be routed to the right accessory
+		this.registeredAccessories = {};
+
+		if (typeof this.config.client_ip_address === `undefined`) {
+			this.log.error(`client_ip_address missing from config; CBus platform disabled.`);
+			return;
+		}
+		this.cgateIpAddress = this.config.client_ip_address;
+		this.cgateControlPort = (typeof this.config.client_controlport === `undefined`)
+			? undefined : this.config.client_controlport;
+
+		try {
+			this.project = CBusNetId.validatedProjectName(this.config.client_cbusname);
+		} catch (err) {
+			this.log.error(`illegal client_cbusname: ${this.config.client_cbusname}; CBus platform disabled.`);
+			return;
+		}
+
+		this.network = (typeof this.config.client_network === `undefined`) ? undefined : this.config.client_network;
+		this.application = (typeof this.config.client_application === `undefined`) ? undefined : this.config.client_application;
+
+		// if set, client_debug overrides the setting in the environment
+		if (typeof this.config.client_debug !== `undefined`) {
+			logClient.enable(this.config.client_debug);
+		}
+
+		this.api.on('didFinishLaunching', () => this._didFinishLaunching());
 	}
-	this.cgateIpAddress = config.client_ip_address;
-	this.cgateControlPort = (typeof config.client_controlport === `undefined`) ? undefined : config.client_controlport;
 
-	// project name, network and default application
-	try {
-		this.project = CBusNetId.validatedProjectName(config.client_cbusname);
-	} catch (err) {
-		throw new Error(`illegal client_cbusname: ${config.client_cbusname}`);
+	// called once per cached accessory restored from homebridge's storage, before didFinishLaunching
+	configureAccessory(platformAccessory) {
+		debug(`Restoring cached accessory '${platformAccessory.displayName}'`);
+		this.cachedAccessories.set(platformAccessory.UUID, platformAccessory);
 	}
 
-	this.network = (typeof config.client_network === `undefined`) ? undefined : config.client_network;
-	this.application = (typeof config.client_application === `undefined`) ? undefined : config.client_application;
+	_didFinishLaunching() {
+		// initiate the CBus client
+		this.client = new CGateClient(this.cgateIpAddress, this.cgateControlPort,
+			this.project, this.network, this.application,
+			this.clientDebug);
 
-	// logging
-	log.enable(true);
+		this.database = new CGateDatabase(new CBusNetId(this.project));
 
-	// if set, client_debug overrides the setting in the environment
-	if (typeof config.client_debug !== `undefined`) {
-		logClient.enable(config.client_debug);
+		// listen for data from the client and ensure that the homebridge UI is updated
+		this.client.on(`event`, message => this._processEvent(message));
+
+		this.client.connect(() => {
+			this.database.fetch(this.client, () => {
+				const stats = this.database.getStats();
+				debug(`Successfully fetched ${stats.numApplications} applications, ${stats.numGroups} groups and ${stats.numUnits} units from C-Gate.`);
+
+				if (this.config.platform_export) {
+					new CGateExport(this.database).exportPlatform(this.config.platform_export, this);
+				}
+
+				if (this.config.database_export) {
+					new CGateExport(this.database).exportDatabase(this.config.database_export);
+				}
+			});
+
+			this._configureAccessories();
+		});
+	}
+
+	_processEvent(message) {
+		if (message.netId) {
+			let output;
+			// lookup accessory
+			const accessory = this.registeredAccessories[message.netId.toString()];
+			if (!message.application === 'measurement') {
+				const tag = this.database ? this.database.getTag(message.netId) : `NYI`;
+				if (accessory) {
+					output = `${chalk.red.bold(accessory.name)} (${accessory.type}) set to level ${message.level}%`;
+				} else {
+					output = `${chalk.red.bold.italic(tag)} (not-registered) set to level ${message.level}%`;
+				}
+			}
+
+			// append source info, if applicable
+			if (message.sourceUnit) {
+				const sourceId = new CBusNetId(this.project, this.network, `p`, message.sourceUnit);
+				const source = this.database.getNetworkEntity(sourceId);
+				if (typeof source === `undefined`) {
+					debug(`event source unit ${sourceId} not found.`);
+				} else {
+					output = `${output}, by ${chalk.red.bold(source.tag)} (${source.unitType})`;
+				}
+			}
+			logLevel(output);
+
+			if (accessory) {
+				// process if found
+				// 702 code for temperature measurement event
+				const err = (message.code !== 730 && !message.code === 702);
+				accessory.processClientData(err, message);
+			}
+		} else if (message.code === 700) {
+			debug(`Heartbeat @ ${message.time}`);
+		} else if (message.code === 751) {
+			debug(`Tag information changed.`);
+		}
+	}
+
+	// build/reconcile accessories against config.json, reusing cached PlatformAccessories
+	// where possible, and registering/unregistering with homebridge as needed
+	_configureAccessories() {
+		if (typeof this.config.accessories === `undefined`) {
+			this.log.error(`Your config.json file is missing the 'accessories' section for this platform. (Check spelling!)`);
+			return;
+		}
+
+		const seenUUIDs = new Set();
+		const newPlatformAccessories = [];
+
+		for (const accessoryConfig of this.config.accessories) {
+			if (accessoryConfig.enabled === false) {
+				debug(`Skipping disabled accessory '${accessoryConfig.name}' (${accessoryConfig.type})`);
+				continue;
+			}
+
+			const Constructor = ACCESSORY_TYPES[accessoryConfig.type];
+			if (!Constructor) {
+				this.log.error(`unknown accessory type '${accessoryConfig.type}' for '${accessoryConfig.name}'; skipping`);
+				continue;
+			}
+
+			let wrapper;
+			try {
+				const uuid = CBusAccessory.uuidFor(this, accessoryConfig);
+				const existing = this.cachedAccessories.get(uuid);
+
+				wrapper = new Constructor(this, accessoryConfig, existing);
+
+				if (!existing) {
+					newPlatformAccessories.push(wrapper.platformAccessory);
+				}
+				seenUUIDs.add(wrapper.platformAccessory.UUID);
+			} catch (err) {
+				this.log.error(`Unable to instantiate accessory '${accessoryConfig.name}' (${accessoryConfig.type}): ${err.message}`);
+				continue;
+			}
+
+			this.registeredAccessories[wrapper.netId.toString()] = wrapper;
+		}
+
+		if (newPlatformAccessories.length > 0) {
+			debug(`Registering ${newPlatformAccessories.length} new accessories…`);
+			this.api.registerPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, newPlatformAccessories);
+		}
+
+		// remove any cached accessories that are no longer present in config.json
+		const staleAccessories = [...this.cachedAccessories.values()].filter(pa => !seenUUIDs.has(pa.UUID));
+		if (staleAccessories.length > 0) {
+			debug(`Removing ${staleAccessories.length} stale cached accessories…`);
+			this.api.unregisterPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, staleAccessories);
+		}
+
+		debug(`Registered ${seenUUIDs.size} accessories in total.`);
 	}
 }
-
-// Invokes callback(accessories[])
-CBusPlatform.prototype._processEvent = function (message) {
-	if (message.netId) {
-		let output;
-		// lookup accessory
-		const accessory = this.registeredAccessories[message.netId.toString()];
-		if (!message.application === 'measurement') {
-			const tag = this.database ? this.database.getTag(message.netId) : `NYI`;
-			if (accessory) {
-				output = `${chalk.red.bold(accessory.name)} (${accessory.type}) set to level ${message.level}%`;
-			} else {
-				output = `${chalk.red.bold.italic(tag)} (not-registered) set to level ${message.level}%`;
-			}
-		}
-
-		// append source info, if applicable
-		if (message.sourceUnit) {
-			const sourceId = new CBusNetId(this.project, this.network, `p`, message.sourceUnit);
-			const source = this.database.getNetworkEntity(sourceId);
-            if (typeof source == 'undefined') {
-                log(`event source unit ${sourceId} not found.`);
-            } else {
-			    output = `${output}, by ${chalk.red.bold(source.tag)} (${source.unitType})`;
-            }
-		}
-		logLevel(output);
-
-		if (accessory) {
-			// process if found
-			// 702 code for temperature measurement event
-			const err = (message.code !== 730 && !message.code === 702);
-			accessory.processClientData(err, message);
-		}
-	} else if (message.code === 700) {
-		log(`Heartbeat @ ${message.time}`);
-	} else if (message.code === 751) {
-		log(`Tag information changed.`);
-	}
-};
-
-CBusPlatform.prototype.accessories = function (callback) {
-	// initiate the CBus client
-	this.client = new CGateClient(this.cgateIpAddress, this.cgateControlPort,
-		this.project, this.network, this.application,
-		this.clientDebug);
-
-	this.database = new CGateDatabase(new CBusNetId(this.project));
-
-	// listen for data from the client and ensure that the homebridge UI is updated
-	this.client.on(`event`, function (message) {
-		this._processEvent(message);
-	}.bind(this));
-
-	this.client.connect(function () {
-		this.database.fetch(this.client, () => {
-			const stats = this.database.getStats();
-			log(`Successfully fetched ${stats.numApplications} applications, ${stats.numGroups} groups and ${stats.numUnits} units from C-Gate.`);
-
-			// export platform file if platform_export property is set
-			if (this.config.platform_export) {
-				new CGateExport(this.database).exportPlatform(this.config.platform_export, this);
-			}
-
-			// export platform file if platform_export property is set
-			if (this.config.database_export) {
-				new CGateExport(this.database).exportDatabase(this.config.database_export);
-			}
-		});
-
-		const accessories = this._createAccessories();
-
-		// build the lookup map
-		this.registeredAccessories = {};
-		for (const accessory of accessories) {
-			this.registeredAccessories[accessory.netId.toString()] = accessory;
-		}
-
-		// hand them back to the callback to fire them up
-		log('Registering the accessories list…');
-		callback(accessories);
-	}.bind(this));
-};
-
-// return a map of newly minted accessories
-CBusPlatform.prototype._createAccessories = function () {
-	log('Loading the accessories list…');
-
-	if (typeof this.config.accessories === `undefined`) {
-		log(`Your config.json file is missing the 'accessories' section for this platform. (Check spelling!)`);
-		process.exit(0);
-	}
-
-	const accessories = [];
-
-	for (let config of this.config.accessories) {
-		if (config.enabled === false) {
-			log(`Skipping disabled accessory '${config.name}' (${config.type})`);
-		} else {
-			try {
-				const accessory = this.createAccessory(config);
-				accessories.push(accessory);
-			} catch (err) {
-				log(`Unable to instantiate accessory '${config.name}' (${config.type}) reason: ${err}. ABORTING`);
-				process.exit(0);
-			}
-		}
-	}
-
-	return accessories;
-};
-
-CBusPlatform.prototype.createAccessory = function (config) {
-	console.assert(typeof config.type === `string`, `accessory missing type property`);
-
-	const constructor = module.exports.accessoryDefinitions[config.type];
-	if (!constructor) {
-		throw new Error(`unknown accessory type '${config.type}'`);
-	}
-
-	return new constructor(this, config);
-};

--- a/lib/cbus-utils.js
+++ b/lib/cbus-utils.js
@@ -1,18 +1,11 @@
 'use strict';
 
-const inherits = require('util').inherits;
-
 const path = require('path');
 const chalk = require('chalk');
 
-// necessary because Accessory is defined after we have defined all of our classes
-module.exports.fixInheritance = function (subclass, superclass) {
-	const proto = subclass.prototype;
-	inherits(subclass, superclass);
-	subclass.prototype.parent = superclass.prototype;
-	for (let mn in proto) {
-		subclass.prototype[mn] = proto[mn];
-	}
+// resolves after the given number of milliseconds
+module.exports.delay = function (ms) {
+	return new Promise(resolve => setTimeout(resolve, ms));
 };
 
 // parse the fromClient as an integer

--- a/lib/cgate-client.js
+++ b/lib/cgate-client.js
@@ -151,13 +151,11 @@ CBusClient.prototype.connect = function (callback) {
 	this.socket.on('error', function (error) {
 		log(`C-Gate socket error: ${error}`);
 
-		if (that.wasOpen) {
-			reopenConnection();
-		} else {
-			// if we've never had a successful connection, then force quit -- yes, a bit heavy handed
-			log(`C-Gate connection could not be opened; exiting.`);
-			process.exit(0);
-		}
+		// retry regardless of whether we've previously connected -- calling process.exit()
+		// here would kill the entire homebridge process, taking every other plugin down
+		// with it, which is far too heavy-handed for what's often just C-Gate not being
+		// up yet (eg. right after a reboot).
+		reopenConnection();
 	});
 
 	this.socket.on('end', function () {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "1.2.0",
   "description": "CBus Platform plugin for homebridge",
   "license": "MIT",
-  "homepage": "http://github.com/anthonywebb/homebridge-cbus/",
+  "author": "ssmcleod",
+  "homepage": "https://github.com/ssmcleod/homebridge-cbus/",
   "keywords": [
     "homebridge-plugin",
     "homebridge",
@@ -19,10 +20,10 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git://github.com/anthonywebb/homebridge-cbus.git"
+    "url": "git+https://github.com/ssmcleod/homebridge-cbus.git"
   },
   "bugs": {
-    "url": "http://github.com/anthonywebb/homebridge-cbus/issues"
+    "url": "https://github.com/ssmcleod/homebridge-cbus/issues"
   },
   "engines": {
     "node": "^18.15.0 || ^20.7.0 || ^22 || ^24",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-cbus",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "CBus Platform plugin for homebridge",
   "license": "MIT",
   "homepage": "http://github.com/anthonywebb/homebridge-cbus/",
@@ -25,8 +25,8 @@
     "url": "http://github.com/anthonywebb/homebridge-cbus/issues"
   },
   "engines": {
-    "node": ">=0.12.0",
-    "homebridge": ">=0.2.0"
+    "node": "^18.15.0 || ^20.7.0 || ^22 || ^24",
+    "homebridge": "^1.6.0 || ^2.0.0"
   },
   "dependencies": {
     "bytes": "^2.4.0",


### PR DESCRIPTION
Homebridge 2.x / HAP-NodeJS 2.x rewrote Accessory as a real ES6 class, which broke this plugin's approach of subclassing it via Accessory.call(this, ...) plus a hand-rolled prototype-copying "fixInheritance" helper (a Node 0.12-era pattern). Every accessory constructor now throws "Class constructor Accessory cannot be invoked without 'new'" on startup, crashing the whole platform in a loop.

This rewrites all 12 accessory types (light, dimmer, switch, fan, shutter, motion, security, trigger, smoke, contact, temperature) to:

- wrap a homebridge PlatformAccessory via composition instead of subclassing hap-nodejs's Accessory
- register as a modern dynamic platform (configureAccessory / registerPlatformAccessories) instead of the deprecated static accessories(callback) style, so accessories are cached across restarts and don't need re-pairing in the Home app
- use onGet/onSet/updateValue() instead of the old .on('get'/'set') + context==='event' loop-guard pattern

Also fixes a couple of related robustness bugs found along the way:
- lib/cgate-client.js called process.exit(0) if the initial C-Gate connection failed, which kills the entire homebridge process (every other plugin included) rather than just this platform; it now retries with the existing backoff instead
- shutter-accessory.js stored the `invert` config flag as a string but compared it against the boolean `true` in one of the two translation directions, so inversion only ever applied to outgoing commands, not incoming position feedback

Bumps engines in package.json to reflect real Node 18+ / Homebridge 1.6+/2.x support. Verified against a live installation running Homebridge 2.2.0, HAP-NodeJS 2.1.9 and Node 22 with 67 real accessories (lights, dimmers, fans, shutters, switches).